### PR TITLE
Basic "Done Assessments" submissions list

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		8384C43D292A8634008CCB4D /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C43C292A8634008CCB4D /* Feedback.swift */; };
 		8384C43F292A9D24008CCB4D /* CorrectionGuidelines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C43E292A9D24008CCB4D /* CorrectionGuidelines.swift */; };
 		8384C441292AA1FB008CCB4D /* GradingCriteriaCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C440292AA1FB008CCB4D /* GradingCriteriaCellView.swift */; };
+		DA0687C2292FB4870091B88A /* SubmissionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0687C1292FB4870091B88A /* SubmissionListView.swift */; };
+		DA249E9629301E72008DE1D5 /* SubmissionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */; };
+		DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */; };
+		DA249E9A293029A3008DE1D5 /* AuthenticatedPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */; };
 		E119ED992922D89900626DEA /* Submission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED982922D89900626DEA /* Submission.swift */; };
 		E119ED9B2922DE4700626DEA /* Assessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9A2922DE4700626DEA /* Assessment.swift */; };
 		E119ED9D2922EE2300626DEA /* PlantUMLConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9C2922EE2300626DEA /* PlantUMLConverter.swift */; };
@@ -106,6 +110,10 @@
 		8384C43E292A9D24008CCB4D /* CorrectionGuidelines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CorrectionGuidelines.swift; path = Themis/ViewModels/CorrectionSidebar/CorrectionGuidelines.swift; sourceTree = SOURCE_ROOT; };
 		8384C440292AA1FB008CCB4D /* GradingCriteriaCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GradingCriteriaCellView.swift; path = Themis/Views/Assessment/CorrectionSidebar/GradingCriteriaCellView.swift; sourceTree = SOURCE_ROOT; };
 		83E729E82915786600DB7B36 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DA0687C1292FB4870091B88A /* SubmissionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionListView.swift; sourceTree = "<group>"; };
+		DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionListViewModel.swift; sourceTree = "<group>"; };
+		DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewAuthenticationViewModel.swift; sourceTree = "<group>"; };
+		DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedPreview.swift; sourceTree = "<group>"; };
 		E119ED982922D89900626DEA /* Submission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Submission.swift; path = Themis/Models/Submission.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9A2922DE4700626DEA /* Assessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Assessment.swift; path = Themis/Models/Assessment.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9C2922EE2300626DEA /* PlantUMLConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlantUMLConverter.swift; path = Themis/API/PlantUMLConverter.swift; sourceTree = SOURCE_ROOT; };
@@ -195,6 +203,7 @@
 		4065F855292E873A005DAEE8 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				DA249E9429301E1B008DE1D5 /* SubmissionList */,
 				4065F85A292E8AB1005DAEE8 /* CourseList */,
 				4065F859292E8A90005DAEE8 /* Assessment */,
 				4065F858292E8A7F005DAEE8 /* Authentication */,
@@ -228,6 +237,7 @@
 			isa = PBXGroup;
 			children = (
 				E2192EE2291E74620092CE58 /* AuthenticationViewModel.swift */,
+				DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */,
 			);
 			name = Authentication;
 			path = Themis/ViewModels/Authentication;
@@ -346,6 +356,22 @@
 			path = Supporting;
 			sourceTree = "<group>";
 		};
+		DA0687C0292FB4610091B88A /* Submissions */ = {
+			isa = PBXGroup;
+			children = (
+				DA0687C1292FB4870091B88A /* SubmissionListView.swift */,
+			);
+			path = Submissions;
+			sourceTree = "<group>";
+		};
+		DA249E9429301E1B008DE1D5 /* SubmissionList */ = {
+			isa = PBXGroup;
+			children = (
+				DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */,
+			);
+			path = SubmissionList;
+			sourceTree = "<group>";
+		};
 		E2192ED1291E47670092CE58 /* REST */ = {
 			isa = PBXGroup;
 			children = (
@@ -373,8 +399,9 @@
 			children = (
 				E21AF042292B9D4C0096ACFC /* Assessment */,
 				4065F856292E87AB005DAEE8 /* AppearanceSettings */,
-				E2E6748629203E280081238B /* Exercises */,
 				E2E674812920326F0081238B /* Courses */,
+				E2E6748629203E280081238B /* Exercises */,
+				DA0687C0292FB4610091B88A /* Submissions */,
 				E2192EE7291EC3100092CE58 /* Authentication */,
 				83396D2F29155935003EF727 /* ContentView.swift */,
 			);
@@ -386,6 +413,7 @@
 			isa = PBXGroup;
 			children = (
 				E2192EE4291EBFFE0092CE58 /* AuthenticationView.swift */,
+				DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */,
 			);
 			name = Authentication;
 			path = Themis/Views/Authentication;
@@ -622,7 +650,9 @@
 				8384C441292AA1FB008CCB4D /* GradingCriteriaCellView.swift in Sources */,
 				8384C43329210488008CCB4D /* ProblemStatementCellView.swift in Sources */,
 				8384C42F29210458008CCB4D /* CorrectionGuidelinesCellView.swift in Sources */,
+				DA249E9A293029A3008DE1D5 /* AuthenticatedPreview.swift in Sources */,
 				E2192EE5291EBFFE0092CE58 /* AuthenticationView.swift in Sources */,
+				DA249E9629301E72008DE1D5 /* SubmissionListViewModel.swift in Sources */,
 				8384C439292A8592008CCB4D /* FeedbackCellView.swift in Sources */,
 				8384C4352922939A008CCB4D /* ProblemStatementCellViewModel.swift in Sources */,
 				E2192ED7291E57810092CE58 /* RESTError.swift in Sources */,
@@ -632,6 +662,7 @@
 				E2192EE3291E74620092CE58 /* AuthenticationViewModel.swift in Sources */,
 				83396D2E29155935003EF727 /* ThemisApp.swift in Sources */,
 				E21AF058292B9D4C0096ACFC /* HighlightName.swift in Sources */,
+				DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */,
 				E21AF056292B9D4C0096ACFC /* ThemeSettings.swift in Sources */,
 				E21AF054292B9D4C0096ACFC /* CodeView.swift in Sources */,
 				E2E460DD29292ECF00ECC0A5 /* Stack.swift in Sources */,
@@ -640,6 +671,7 @@
 				E2192ED3291E47820092CE58 /* RESTController.swift in Sources */,
 				E21AF059292B9D4C0096ACFC /* AppearanceSettingsView.swift in Sources */,
 				8384C42B2920F855008CCB4D /* CorrectionSidebarView.swift in Sources */,
+				DA0687C2292FB4870091B88A /* SubmissionListView.swift in Sources */,
 				0BEC4C37292EA32A00F9F802 /* CodeEditorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -785,6 +817,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;

--- a/Themis/Models/Submission.swift
+++ b/Themis/Models/Submission.swift
@@ -10,8 +10,7 @@ import Foundation
 struct Student: Codable {
     let id: Int
     let login: String
-    let firstName: String
-    let lastName: String
+    let name: String
     let email: String
 }
 
@@ -35,7 +34,7 @@ struct SubmissionParticipation: Codable {
 struct Submission: Codable {
     let id: Int
     let participation: SubmissionParticipation
-    let results: SubmissionResult
+    let results: [SubmissionResult]
 }
 
 struct SubmissionForAssessment: Codable {
@@ -45,9 +44,13 @@ struct SubmissionForAssessment: Codable {
 }
 
 extension ArtemisAPI {
-    /// Gets all submissions of that exercise.
-    static func getAllSubmissions(exerciseId: Int) async throws -> [Submission] {
-        let request = Request(method: .get, path: "/api/exercises/\(exerciseId)/programming-submissions")
+    /// Gets all submissions of that exercise assessed by the tutor = by the user.
+    static func getTutorSubmissions(exerciseId: Int) async throws -> [Submission] {
+        let request = Request(
+            method: .get,
+            path: "/api/exercises/\(exerciseId)/programming-submissions",
+            params: [URLQueryItem(name: "assessedByTutor", value: "true")]
+        )
         return try await sendRequest([Submission].self, request: request)
     }
 

--- a/Themis/Models/Submission.swift
+++ b/Themis/Models/Submission.swift
@@ -28,7 +28,7 @@ struct SubmissionResult: Codable {
     let id: Int
     let score: Double
     let rated: Bool
-    let hasFeedback: Bool
+    let hasFeedback: Bool?
     let testCaseCount: Int
     let passedTestCaseCount: Int
     let codeIssueCount: Int

--- a/Themis/Models/Submission.swift
+++ b/Themis/Models/Submission.swift
@@ -10,8 +10,18 @@ import Foundation
 struct Student: Codable {
     let id: Int
     let login: String
-    let name: String
+    let firstName: String
+    let lastName: String?
     let email: String
+
+    var name: String {
+        get {
+            guard let lastName = lastName else {
+                return firstName
+            }
+            return "\(firstName) \(lastName)"
+        }
+    }
 }
 
 struct SubmissionResult: Codable {
@@ -49,7 +59,7 @@ extension ArtemisAPI {
         let request = Request(method: .get, path: "/api/exercises/\(exerciseId)/programming-submissions")
         return try await sendRequest([Submission].self, request: request)
     }
-    
+
     /// Gets all submissions of that exercise assessed by the tutor = by the user.
     static func getTutorSubmissions(exerciseId: Int) async throws -> [Submission] {
         let request = Request(

--- a/Themis/Models/Submission.swift
+++ b/Themis/Models/Submission.swift
@@ -44,6 +44,12 @@ struct SubmissionForAssessment: Codable {
 }
 
 extension ArtemisAPI {
+    /// Gets all submissions of that exercise.
+    static func getAllSubmissions(exerciseId: Int) async throws -> [Submission] {
+        let request = Request(method: .get, path: "/api/exercises/\(exerciseId)/programming-submissions")
+        return try await sendRequest([Submission].self, request: request)
+    }
+    
     /// Gets all submissions of that exercise assessed by the tutor = by the user.
     static func getTutorSubmissions(exerciseId: Int) async throws -> [Submission] {
         let request = Request(

--- a/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
@@ -39,14 +39,18 @@ class AuthenticationViewModel: ObservableObject {
     private var restControllerInitialized = false
     private var cancellable = Set<AnyCancellable>()
 
-    init() {
-        self.serverURL = "https://artemis-staging.ase.in.tum.de"
+    init(serverURL: String) {
+        self.serverURL = serverURL
         if let serverURL = URL(string: serverURL) {
             RESTController.shared = RESTController(baseURL: serverURL)
             restControllerInitialized = true
         }
         Authentication.shared = Authentication()
         observeAuthenticationToken()
+    }
+
+    convenience init() {
+        self.init(serverURL: "https://artemis-staging.ase.in.tum.de")
     }
 
     /// Observing the Authentication Token will always change the @Published authenticated Bool  to the correct Value

--- a/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
@@ -79,7 +79,9 @@ class AuthenticationViewModel: ObservableObject {
         } catch RESTError.unauthorized {
             self.invalidCredentialsAlert.toggle()
         } catch let error {
-            print(error.localizedDescription)
+            // converting to string gives nicer errors,
+            // see https://stackoverflow.com/a/68044439/4306257
+            print(String(describing: error))
         }
     }
 

--- a/Themis/ViewModels/Authentication/PreviewAuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/PreviewAuthenticationViewModel.swift
@@ -12,7 +12,8 @@
 /// - ARTEMIS_STAGING_SERVER
 /// - ARTEMIS_STAGING_USER
 /// - ARTEMIS_STAGING_PASSWORD
-/// Consult https://m25lazi.medium.com/environment-variables-in-xcode-a78e07d223ed for an explanation on how to configure them.
+/// Consult https://confluence.ase.in.tum.de/display/IOS2223CIT/Authentication+Preview+Setup for an explanation on how to configure them.
+/// (alternative for people without access: https://m25lazi.medium.com/environment-variables-in-xcode-a78e07d223ed)
 
 import Foundation
 

--- a/Themis/ViewModels/Authentication/PreviewAuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/PreviewAuthenticationViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  PreviewAuthenticationViewModel.swift
+//  Themis
+//
+//  Created by Paul Schwind on 24.11.22.
+//
+
+/// This is an AuthenticationViewModel you can use for the XCode preview feature.
+/// Usually, you would have to somehow log in, but would be quite annoying and would also duplicate a lot of code.
+/// Instead, you can just use a PreviewAuthenticationViewModel, which will automatically log in using credentials found in your environment.
+/// For this to work, you have to edit the Themis scheme in XCode to include the following environment variables:
+/// - ARTEMIS_STAGING_SERVER
+/// - ARTEMIS_STAGING_USER
+/// - ARTEMIS_STAGING_PASSWORD
+/// Consult https://m25lazi.medium.com/environment-variables-in-xcode-a78e07d223ed for an explanation on how to configure them.
+
+import Foundation
+
+class PreviewAuthenticationViewModel: AuthenticationViewModel {
+    static let SERVER_ENV_VAR = "ARTEMIS_STAGING_SERVER"
+    static let USER_ENV_VAR = "ARTEMIS_STAGING_USER"
+    static let PASSWORD_ENV_VAR = "ARTEMIS_STAGING_PASSWORD"
+
+    init() {
+        guard let serverURL = ProcessInfo.processInfo.environment[Self.SERVER_ENV_VAR] else {
+            fatalError("Set \(Self.SERVER_ENV_VAR) in the environment to use PreviewAuthenticationViewModel.")
+        }
+        super.init(serverURL: serverURL)
+        guard let username = ProcessInfo.processInfo.environment[Self.USER_ENV_VAR] else {
+            fatalError("Set \(Self.USER_ENV_VAR) in the environment to use PreviewAuthenticationViewModel.")
+        }
+        self.username = username
+        guard let password = ProcessInfo.processInfo.environment[Self.PASSWORD_ENV_VAR] else {
+            fatalError("Set \(Self.PASSWORD_ENV_VAR) in the environment to use PreviewAuthenticationViewModel.")
+        }
+        self.password = password
+        Task {
+            await self.authenticate()
+        }
+    }
+}

--- a/Themis/ViewModels/SubmissionList/SubmissionListViewModel.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionListViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  SubmissionListViewModel.swift
+//  Themis
+//
+//  Created by Paul Schwind on 24.11.22.
+//
+
+import Foundation
+
+class SubmissionListViewModel: ObservableObject {
+    @Published var submissions: [Submission] = []
+
+    @MainActor
+    func fetchTutorSubmissions(exerciseId: Int) async {
+        do {
+            self.submissions = try await ArtemisAPI.getTutorSubmissions(exerciseId: exerciseId)
+        } catch let error {
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/Themis/Views/Authentication/AuthenticatedPreview.swift
+++ b/Themis/Views/Authentication/AuthenticatedPreview.swift
@@ -1,0 +1,24 @@
+//
+//  AuthenticatedPreview.swift
+//  Themis
+//
+//  Created by Paul Schwind on 24.11.22.
+//
+
+/// Wrap your preview with this component if you need authentication.
+
+import SwiftUI
+
+struct AuthenticatedPreview<Content: View>: View {
+    @StateObject var authenticationVM = PreviewAuthenticationViewModel()
+    let contentBuilder: () -> Content
+
+    @ViewBuilder
+    var body: some View {
+        if authenticationVM.authenticated {
+            contentBuilder()
+        } else {
+            Text("Authenticating...")
+        }
+    }
+}

--- a/Themis/Views/ContentView.swift
+++ b/Themis/Views/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
         /*VStack {
             if authenticationVM.authenticated {
                 CourseListView(authenticationVM: authenticationVM)
+                // SubmissionListView(exerciseId: 5284)
             } else {
                 AuthenticationView(authenticationVM: authenticationVM)
             }
@@ -21,12 +22,14 @@ struct ContentView: View {
         .onAppear {
             authenticationVM.searchForToken()
         }
-        .padding()*/
+        .padding()
+         */
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView(authenticationVM: PreviewAuthenticationViewModel())
+            .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/Themis/Views/ContentView.swift
+++ b/Themis/Views/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     @StateObject var authenticationVM = AuthenticationViewModel()
     var body: some View {
+        // SubmissionListView(exerciseId: 5284)
         VStack {
             if authenticationVM.authenticated {
                 // AssessmentView()

--- a/Themis/Views/Submissions/SubmissionListView.swift
+++ b/Themis/Views/Submissions/SubmissionListView.swift
@@ -1,0 +1,44 @@
+//
+//  SubmissionsListView.swift
+//  Themis
+//
+//  Created by Paul Schwind on 24.11.22.
+//
+
+import SwiftUI
+
+struct SubmissionListView: View {
+    var exerciseId: Int
+    @StateObject var submissionListVM = SubmissionListViewModel()
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(submissionListVM.submissions, id: \.id) { submission in
+                    NavigationLink {
+                    } label: {
+                        Text("Submission \(submission.id) by \(submission.participation.student.name)")
+                    }
+                }
+            }
+            .overlay(Group {
+                if submissionListVM.submissions.isEmpty {
+                    Text("No submissions")
+                }
+            })
+        }
+        .navigationTitle("Your Submissions")
+        .task {
+            await submissionListVM.fetchTutorSubmissions(exerciseId: exerciseId)
+        }
+    }
+}
+
+struct SubmissionListView_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthenticatedPreview {
+            SubmissionListView(exerciseId: 5284)
+        }
+        .previewInterfaceOrientation(.landscapeLeft)
+    }
+}


### PR DESCRIPTION
- This PR includes just a basic view of the done assessments of the tutor for a given exercise.
- The view is not done yet, but it's mergable.
- It uses API data. I had to do some minor fixes to the models because the data provided by the API is slightly different (no `Student.lastName`, `Submission.results` is a list).
- There now is a way to easily preview components which need authentication to work.
- The authenticated preview needs some minor setup work: https://confluence.ase.in.tum.de/display/IOS2223CIT/Authentication+Preview+Setup
