### PR TITLE
FlatMap for Filetree implemented

### DIFF
--- a/Themis/Models/Repository.swift
+++ b/Themis/Models/Repository.swift
@@ -49,7 +49,7 @@ class Node: Hashable {
     func flatMap() {
         guard let children, type == .folder else { return }
         if let childFolder = children.first, childFolder.type == .folder, children.count == 1 {
-            self.name = self.name + "/" + childFolder.name
+            self.name += "/" + childFolder.name // WTF Swiftlint enforece to use += lol
             self.children?.removeFirst()
             self.children = childFolder.children
             self.flatMap()

--- a/Themis/Models/Repository.swift
+++ b/Themis/Models/Repository.swift
@@ -44,8 +44,8 @@ class Node: Hashable {
     var path: String {
         calculatePath().joined(separator: "/")
     }
-    
-    ///This Method will flatMap children that have only one folder
+
+    /// This Method will flatMap children that have only one folder
     func flatMap() {
         guard let children, type == .folder else { return }
         if let childFolder = children.first, childFolder.type == .folder, children.count == 1 {

--- a/Themis/Models/Repository.swift
+++ b/Themis/Models/Repository.swift
@@ -44,6 +44,21 @@ class Node: Hashable {
     var path: String {
         calculatePath().joined(separator: "/")
     }
+    
+    ///This Method will flatMap children that have only one folder
+    func flatMap() {
+        guard let children, type == .folder else { return }
+        if let childFolder = children.first, childFolder.type == .folder, children.count == 1 {
+            self.name = self.name + "/" + childFolder.name
+            self.children?.removeFirst()
+            self.children = childFolder.children
+            self.flatMap()
+        } else {
+            for child in children {
+                child.flatMap()
+            }
+        }
+    }
 
     private func calculatePath() -> [String] {
         var parentPath = parent?.calculatePath() ?? []
@@ -124,7 +139,7 @@ extension ArtemisAPI {
         let timeInterval = Double(nanoTime) / 1_000_000_000
 
         print("Time to evaluate Parse: \(timeInterval) seconds")
-
+        root.flatMap()
         return root
     }
 


### PR DESCRIPTION
### File Tree FlatMap
The File tree is annoying to use if a folder has only one subfolder.
Therefore I implemented a FlatMap Operation which transforms the given tree into a tree where 
nodes with only one folder are merged together. (See picture)

![flat_file_tree](https://user-images.githubusercontent.com/16856573/203977722-4d6fff8c-e26a-4eef-9c91-b91d6416657b.png)
