### PR TITLE
Implement environment flag to allow bearer tokens again

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		DA249E9629301E72008DE1D5 /* SubmissionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */; };
 		DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */; };
 		DA249E9A293029A3008DE1D5 /* AuthenticatedPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */; };
+		DA6E32932936156E001D599F /* BearerTokenAuthToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA6E32922936156E001D599F /* BearerTokenAuthToggle.swift */; };
 		E119ED992922D89900626DEA /* Submission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED982922D89900626DEA /* Submission.swift */; };
 		E119ED9B2922DE4700626DEA /* Assessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9A2922DE4700626DEA /* Assessment.swift */; };
 		E119ED9D2922EE2300626DEA /* PlantUMLConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9C2922EE2300626DEA /* PlantUMLConverter.swift */; };
@@ -113,6 +114,7 @@
 		DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionListViewModel.swift; sourceTree = "<group>"; };
 		DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewAuthenticationViewModel.swift; sourceTree = "<group>"; };
 		DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedPreview.swift; sourceTree = "<group>"; };
+		DA6E32922936156E001D599F /* BearerTokenAuthToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BearerTokenAuthToggle.swift; sourceTree = "<group>"; };
 		E119ED982922D89900626DEA /* Submission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Submission.swift; path = Themis/Models/Submission.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9A2922DE4700626DEA /* Assessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Assessment.swift; path = Themis/Models/Assessment.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9C2922EE2300626DEA /* PlantUMLConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlantUMLConverter.swift; path = Themis/API/PlantUMLConverter.swift; sourceTree = SOURCE_ROOT; };
@@ -389,6 +391,7 @@
 				E2192EDB291E59CC0092CE58 /* ArtemisAPI.swift */,
 				E119ED9C2922EE2300626DEA /* PlantUMLConverter.swift */,
 				E2E460DC29292ECF00ECC0A5 /* Stack.swift */,
+				DA6E32922936156E001D599F /* BearerTokenAuthToggle.swift */,
 			);
 			name = API;
 			path = Themis/API;
@@ -643,6 +646,7 @@
 				E119ED992922D89900626DEA /* Submission.swift in Sources */,
 				E119ED9D2922EE2300626DEA /* PlantUMLConverter.swift in Sources */,
 				8384C43B292A85E0008CCB4D /* FeedbackViewModel.swift in Sources */,
+				DA6E32932936156E001D599F /* BearerTokenAuthToggle.swift in Sources */,
 				83396D3029155935003EF727 /* ContentView.swift in Sources */,
 				0BEC4C35292EA1A400F9F802 /* FiletreeSidebarView.swift in Sources */,
 				E21AF055292B9D4C0096ACFC /* TabsView.swift in Sources */,

--- a/Themis/API/ArtemisAPI.swift
+++ b/Themis/API/ArtemisAPI.swift
@@ -9,10 +9,26 @@ import Foundation
 
 class ArtemisAPI {
     static func sendRequest<T: Decodable>(_ type: T.Type, request: Request) async throws -> T {
-        try await RESTController.shared.sendRequest(request)
+        if bearerTokenAuth {
+            var request = request
+            guard let token = Authentication.shared.token else {
+                throw Authentication.AuthenticationError.tokenNotFound
+            }
+            request.setBeaererToken(token: token)
+            return try await RESTController.shared.sendRequest(request)
+        }
+        return try await RESTController.shared.sendRequest(request)
     }
 
     static func sendRequest<T>(_ type: T.Type, request: Request, decode: (Data) throws -> T) async throws -> T {
-        try await RESTController.shared.sendRequest(request, decode: decode)
+        if bearerTokenAuth {
+            var request = request
+            guard let token = Authentication.shared.token else {
+                throw Authentication.AuthenticationError.tokenNotFound
+            }
+            request.setBeaererToken(token: token)
+            return try await RESTController.shared.sendRequest(request, decode: decode)
+        }
+        return try await RESTController.shared.sendRequest(request, decode: decode)
     }
 }

--- a/Themis/API/BearerTokenAuthToggle.swift
+++ b/Themis/API/BearerTokenAuthToggle.swift
@@ -1,0 +1,10 @@
+//
+//  CookieAuthToggle.swift
+//  Themis
+//
+//  Created by Paul Schwind on 29.11.22.
+//
+
+import Foundation
+
+var bearerTokenAuth: Bool = ProcessInfo.processInfo.environment["USE_BEARER_TOKEN_AUTH"] == "true"

--- a/Themis/Models/Authentication.swift
+++ b/Themis/Models/Authentication.swift
@@ -18,22 +18,79 @@ class Authentication: NSObject {
 
     static var shared: Authentication!
 
+    // TODO: remove after bearer token auth is no more
+    enum AuthenticationError: Error {
+        case tokenNotFound
+    }
+    @objc dynamic var token: String?
+    let keychain: Keychain
+    // end TODO
+
     let url: URL
 
     @objc dynamic var authenticated: Bool = false
 
     init(for url: URL) {
         self.url = url
+        keychain = Keychain(service: "feedback2go.auth")
         super.init()
     }
+
+    // TODO: remove after bearer token auth is gone
+    func storeTokenInKeychain(token: String) {
+        DispatchQueue.global().async {
+            do {
+                try self.keychain
+                    .accessibility(.whenPasscodeSetThisDeviceOnly, authenticationPolicy: [.biometryAny])
+                    .set(token, key: "token")
+            } catch let error {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    func getTokenFromKeychain() {
+        DispatchQueue.global().async {
+            do {
+                self.token = try self.keychain
+                    .authenticationPrompt("Authenticate to login to App")
+                    .get("token")
+            } catch let error {
+                print(error.localizedDescription)
+            }
+        }
+    }
+
+    func deleteToken() {
+        do {
+            try keychain.remove("token")
+            self.token = nil
+        } catch let error {
+            print(error.localizedDescription)
+        }
+    }
+
+    func parseAuth(data: Data) throws -> String {
+        let decoder = JSONDecoder()
+        let decodedData = try decoder.decode([String: String].self, from: data)
+        guard let token = decodedData["id_token"] else {
+            throw AuthenticationError.tokenNotFound
+        }
+        return token
+    }
+    // end TODO
 
     /// This Method allows the user to Authenticate. If it doesnt throw an Error the token will be set as a cookie
     /// If the rememberMe flag is set the token will be valid for 30 Days (if not 30 minutes)
     func auth(username: String, password: String, rememberMe: Bool = false) async throws {
         let body = AuthBody(username: username, password: password, rememberMe: rememberMe)
         let request = Request(method: .post, path: "/api/authenticate", body: body)
-        try await RESTController.shared.sendRequest(request)
-        checkAuth()
+        if bearerTokenAuth {
+            self.token = try await RESTController.shared.sendRequest(request) { try parseAuth(data: $0) }
+        } else {
+            try await RESTController.shared.sendRequest(request)
+            checkAuth()
+        }
     }
 
     func logOut() async throws {

--- a/Themis/Views/ContentView.swift
+++ b/Themis/Views/ContentView.swift
@@ -20,6 +20,11 @@ struct ContentView: View {
                 AuthenticationView(authenticationVM: authenticationVM)
             }
         }
+        .onAppear {
+            if bearerTokenAuth {
+                authenticationVM.searchForToken()
+            }
+        }
         .padding()
     }
 }


### PR DESCRIPTION
This PR re-enables bearer token authentication based on a flag so that we can continue to test and are independent of Artemis staging going back and forth.

Instructions on how to enable: https://confluence.ase.in.tum.de/display/IOS2223CIT/Authentication+Setup