### PR TITLE
AssessmentView fixes

### DIFF
--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -36,22 +36,6 @@ class CodeEditorViewModel: ObservableObject {
         selectedFile = file
     }
 
-    func applySyntaxHighlighting(on textView: TextView) {
-        if let selectedFile = selectedFile, let code = selectedFile.code {
-            switch selectedFile.fileExtension {
-            case .swift:
-                textView.setLanguageMode(TreeSitterLanguageMode(language: .swift), completion: { _ in
-                    textView.text = code })
-            case .java:
-                textView.setLanguageMode(TreeSitterLanguageMode(language: .java), completion: { _ in
-                    textView.text = code })
-            case .other:
-                textView.setLanguageMode(PlainTextLanguageMode(), completion: { _ in
-                    textView.text = code })
-            }
-        }
-    }
-
     func closeFile(file: Node) {
         openFiles = openFiles.filter({ $0.path != file.path })
         selectedFile = openFiles.first

--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -35,6 +35,7 @@ struct AssessmentView: View {
                 rightGrip
                     .edgesIgnoringSafeArea(.bottom)
                 correctionWithPlaceholder
+                    .frame(width: dragWidthRight)
             }
             .animation(.default, value: showFileTree)
             Button {
@@ -235,12 +236,9 @@ struct AssessmentView: View {
         // TODO: ViewModifier for conditional redacted + remove redacted and remove text when to small as way to laggy
         VStack {
             if correctionAsPlaceholder {
-                CorrectionSidebarView()
-                    .frame(width: dragWidthRight)
-                    .redacted(reason: .placeholder)
+                EmptyView()
             } else {
                 CorrectionSidebarView()
-                    .frame(width: dragWidthRight)
             }
         }
     }

--- a/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
@@ -8,14 +8,14 @@ struct CodeEditorView: View {
 
     var body: some View {
         VStack {
-            if cvm.selectedFile != nil {
+            if let file = cvm.selectedFile {
                 VStack {
                     HStack {
                         Spacer()
                             .frame(width: showFileTree ? 0 : 40)
                         TabsView()
                     }
-                    CodeView()
+                    CodeView(file: file)
                 }
             } else {
                 Text("Select a file")

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -7,7 +7,7 @@ import UIKit
 // integrates the UITextView of runestone in SwiftUI
 struct CodeView: UIViewControllerRepresentable {
     @EnvironmentObject var cvm: CodeEditorViewModel
-    
+
     typealias UIViewControllerType = ViewController
     func makeUIViewController(context: Context) -> ViewController {
         let viewController = ViewController()
@@ -15,7 +15,7 @@ struct CodeView: UIViewControllerRepresentable {
         viewController.file = cvm.selectedFile
         return viewController
     }
-    
+
     func updateUIViewController(_ uiViewController: ViewController, context: Context) {
         uiViewController.fontSize = cvm.editorFontSize
         uiViewController.file = cvm.selectedFile
@@ -23,18 +23,18 @@ struct CodeView: UIViewControllerRepresentable {
             uiViewController.textView.highlightedRanges = cvm.inlineHighlights[selectedFile.path] ?? []
         }
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+
     class Coordinator: NSObject, TextViewDelegate {
         var parent: CodeView
-        
+
         init(_ parent: CodeView) {
             self.parent = parent
         }
-        
+
         func textViewDidChangeSelection(_ textView: TextView) {
             if textView.selectedRange.length > 0 {
                 parent.cvm.currentlySelecting = true
@@ -56,6 +56,7 @@ class ViewController: UIViewController {
             if textView.theme.font.pointSize != fontSize {
                 textView.setState(TextViewState(text: textView.text,
                                                 theme: ThemeSettings(font: .systemFont(ofSize: fontSize))))
+                applySyntaxHighlighting(on: textView, file: file)
             }
         }
     }
@@ -79,7 +80,7 @@ class ViewController: UIViewController {
             textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
-    
+
     private func setCustomization(on textView: TextView) {
         textView.backgroundColor = .systemBackground
         textView.lineHeightMultiplier = 1.3
@@ -90,7 +91,7 @@ class ViewController: UIViewController {
         textView.isEditable = false
         textView.lineBreakMode = .byWordWrapping
     }
-    
+
     private func applySyntaxHighlighting(on textView: TextView, file: Node?) {
         if let file = file, let code = file.code {
             switch file.fileExtension {

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -67,11 +67,13 @@ class ViewController: UIViewController {
             if textView.text != file?.code {
                 applySyntaxHighlighting(on: textView)
             }
+        }
+    }
 
     init(cvm: CodeEditorViewModel) {
-            self.cvm = cvm
-            super.init(nibName: nil, bundle: nil)
-        }
+        self.cvm = cvm
+        super.init(nibName: nil, bundle: nil)
+    }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -121,6 +123,7 @@ class ViewController: UIViewController {
                 textView.setState(TextViewState(text: code))
             }
         }
+    }
     private func setupLongPressInteraction() {
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
         textView.addGestureRecognizer(longPressGestureRecognizer)

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -7,21 +7,20 @@ import UIKit
 // integrates the UITextView of runestone in SwiftUI
 struct CodeView: UIViewControllerRepresentable {
     @EnvironmentObject var cvm: CodeEditorViewModel
+    @ObservedObject var file: Node
 
     typealias UIViewControllerType = ViewController
     func makeUIViewController(context: Context) -> ViewController {
         let viewController = ViewController()
         viewController.textView.editorDelegate = context.coordinator
-        viewController.file = cvm.selectedFile
+        viewController.file = file
         return viewController
     }
 
     func updateUIViewController(_ uiViewController: ViewController, context: Context) {
         uiViewController.fontSize = cvm.editorFontSize
-        uiViewController.file = cvm.selectedFile
-        if let selectedFile = cvm.selectedFile {
-            uiViewController.textView.highlightedRanges = cvm.inlineHighlights[selectedFile.path] ?? []
-        }
+        uiViewController.file = file
+        uiViewController.textView.highlightedRanges = cvm.inlineHighlights[file.path] ?? []
     }
 
     func makeCoordinator() -> Coordinator {

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -72,6 +72,7 @@ class ViewController: UIViewController {
     }
 
     private func setCustomization(on textView: TextView) {
+        textView.backgroundColor = .systemBackground
         textView.lineHeightMultiplier = 1.3
         textView.showLineNumbers = true
         textView.showSpaces = true

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -56,17 +56,18 @@ class ViewController: UIViewController {
             if textView.theme.font.pointSize != fontSize {
                 textView.setState(TextViewState(text: textView.text,
                                                 theme: ThemeSettings(font: .systemFont(ofSize: fontSize))))
-                applySyntaxHighlighting(on: textView, file: file)
+                applySyntaxHighlighting(on: textView)
             }
         }
     }
     var file: Node? {
         didSet {
             if textView.text != file?.code {
-                applySyntaxHighlighting(on: textView, file: file)
+                applySyntaxHighlighting(on: textView)
             }
         }
     }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.scrollEdgeAppearance = UINavigationBarAppearance()
@@ -92,18 +93,15 @@ class ViewController: UIViewController {
         textView.lineBreakMode = .byWordWrapping
     }
 
-    private func applySyntaxHighlighting(on textView: TextView, file: Node?) {
+    private func applySyntaxHighlighting(on textView: TextView) {
         if let file = file, let code = file.code {
             switch file.fileExtension {
             case .swift:
-                textView.setLanguageMode(TreeSitterLanguageMode(language: .swift), completion: { _ in
-                    textView.text = code })
+                textView.setState(TextViewState(text: code, language: .swift))
             case .java:
-                textView.setLanguageMode(TreeSitterLanguageMode(language: .java), completion: { _ in
-                    textView.text = code })
+                textView.setState(TextViewState(text: code, language: .java))
             case .other:
-                textView.setLanguageMode(PlainTextLanguageMode(), completion: { _ in
-                    textView.text = code })
+                textView.setState(TextViewState(text: code))
             }
         }
     }

--- a/Themis/Views/ContentView.swift
+++ b/Themis/Views/ContentView.swift
@@ -25,7 +25,6 @@ struct ContentView: View {
                 authenticationVM.searchForToken()
             }
         }
-        .padding()
     }
 }
 


### PR DESCRIPTION
- Made darkmode work again
- removed the unnecessary padding that was around all views
- switched the laggy placeholder CorrectionSidebar with an empty view to indicate its minimal width
- fixed the laggy behaviour of codeview while selecting 
- CodeView now displays the code as soon as it is fetched (no more double clicking required)

(Somehow the CodeViews syntax highlighting is still reapplied everytime when the views width is changed by one of the sidebars. I don't know why that is, as updateUIViewController() is not triggered by that, so maybe it is a runestone problem)
Something we also need to fix is that a Nodes code is only displayed when it is already fetched, which is why you have to click it twice at the moment