### PR TITLE
add real artemis uml diagram to problem statement

### DIFF
--- a/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
+++ b/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
@@ -66,7 +66,7 @@ class ProblemStatementCellViewModel: ObservableObject {
 
     func replaceTestsColor(_ problemStatement: String) -> String {
         return problemStatement
-            .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: "red", options: .regularExpression) // replace test color by red (or green)
+            .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: "black", options: .regularExpression) // replace test color by red (or green)
             // .replacingOccurrences(of: "testsColor(testAttributes[.*])", with: "", options: .regularExpression)
             // .replacingOccurrences(of: "testsColor(testMethods[.*])", with: "", options: .regularExpression)
             // .replacingOccurrences(of: "testsColor(testClass[.*])", with: "", options: .regularExpression)

--- a/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
+++ b/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
@@ -51,6 +51,7 @@ class ProblemStatementCellViewModel: ObservableObject {
 
             // Append plantuml
             substring = String(problemStatement[rangeStart.lowerBound...rangeEnd.upperBound])
+            substring = replaceTestsColor(substring)
             problemStatementParts.append(ProblemStatementPlantUML(text: substring))
 
             index = problemStatement.index(rangeEnd.upperBound, offsetBy: 1)
@@ -61,5 +62,13 @@ class ProblemStatementCellViewModel: ObservableObject {
         return problemStatement
             .replacingOccurrences(of: "[task][", with: "") // to remove symbol
             .replacingOccurrences(of: "](.*())", with: "", options: .regularExpression) // to remove tests
+    }
+
+    func replaceTestsColor(_ problemStatement: String) -> String {
+        return problemStatement
+            .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: "red", options: .regularExpression) // replace test color by red (or green)
+            // .replacingOccurrences(of: "testsColor(testAttributes[.*])", with: "", options: .regularExpression)
+            // .replacingOccurrences(of: "testsColor(testMethods[.*])", with: "", options: .regularExpression)
+            // .replacingOccurrences(of: "testsColor(testClass[.*])", with: "", options: .regularExpression)
     }
 }

--- a/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
@@ -16,7 +16,7 @@ struct ProblemStatementCellView: View {
 
     var body: some View {
         HStack {
-            LazyVStack(alignment: .leading, spacing: 40) {
+            VStack(alignment: .leading, spacing: 40) {
                 Text("Problem Statement")
                     .font(.largeTitle)
 
@@ -24,6 +24,7 @@ struct ProblemStatementCellView: View {
                     if let puml = part as? ProblemStatementPlantUML {
                         AsyncImage(url: puml.url) { image in
                             image.resizable()
+                                .aspectRatio(contentMode: .fit)
                         } placeholder: {
                             ProgressView()
                         }


### PR DESCRIPTION
This pull request add the real UML diagrams downloaded from Artemis to the Problem Statement. In the first step all methods and UML arrows are red (unimplemented). In a next step, their color depends on the real tests.