### PR TITLE
Add support for multiline feedbacks and column references

### DIFF
--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -65,6 +65,9 @@ struct AssessmentFeedback: Encodable, Identifiable {
         guard let columns = columns else {
             return file.name + " at Lines: \(lines.location)-\(lines.location + lines.length)"
         }
+        if columns.length == 0 {
+            return file.name + " at Line: \(lines.location) Col: \(columns.location)"
+        }
         return file.name + " at Line: \(lines.location) Col: \(columns.location)-\(columns.location + columns.length)"
     } /// max length = 500
     var detailText: String /// max length = 5000

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -36,8 +36,8 @@ struct AssessmentResult: Encodable {
         feedbacks.filter { $0.type == .inline }
     }
 
-    mutating func addFeedback(id: UUID = UUID(), detailText: String, credits: Double, type: FeedbackType, file: Node? = nil, line: Int? = nil) {
-        feedbacks.append(AssessmentFeedback(id: id, detailText: detailText, credits: credits, type: type, file: file, line: line))
+    mutating func addFeedback(id: UUID = UUID(), detailText: String, credits: Double, type: FeedbackType, file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) {
+        feedbacks.append(AssessmentFeedback(id: id, detailText: detailText, credits: credits, type: type, file: file, lines: lines, columns: columns))
     }
 
     mutating func deleteFeedback(id: UUID) {
@@ -55,17 +55,21 @@ struct AssessmentResult: Encodable {
 struct AssessmentFeedback: Encodable, Identifiable {
     let id: UUID
     var text: String {
-        guard let file = file, let line = line else {
-            return ""
+        if let file = file, let lines = lines {
+            if let columns = columns {
+                return file.name + " at Line: \(lines.location) Col: \(columns.location)-\(columns.location + columns.length)"
+            }
+            return file.name + " at Lines: \(lines.location)-\(lines.location + lines.length)"
         }
-        return file.name + " at line \(line)"
+        return ""
     } /// max length = 500
     var detailText: String /// max length = 5000
     var credits: Double /// score of element
     let type: FeedbackType
 
     var file: Node?
-    var line: Int?
+    var lines: NSRange?
+    var columns: NSRange?
 
     enum CodingKeys: CodingKey {
         case text

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -56,13 +56,16 @@ struct AssessmentResult: Encodable {
 struct AssessmentFeedback: Encodable, Identifiable {
     let id: UUID
     var text: String {
-        if let file = file, let lines = lines {
-            if let columns = columns {
-                return file.name + " at Line: \(lines.location) Col: \(columns.location)-\(columns.location + columns.length)"
-            }
+        guard let file = file, let lines = lines else {
+            return ""
+        }
+        if lines.location == 0 {
+            return ""
+        }
+        guard let columns = columns else {
             return file.name + " at Lines: \(lines.location)-\(lines.location + lines.length)"
         }
-        return ""
+        return file.name + " at Line: \(lines.location) Col: \(columns.location)-\(columns.location + columns.length)"
     } /// max length = 500
     var detailText: String /// max length = 5000
     var credits: Double /// score of element

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -14,7 +14,7 @@ enum FeedbackType {
 
 struct AssessmentResult: Encodable {
     var score: Double {
-        feedbacks.reduce(0) { $0 + $1.credits}
+        feedbacks.reduce(0) { $0 + $1.credits }
     }
     var feedbacks: [AssessmentFeedback]
 
@@ -36,7 +36,8 @@ struct AssessmentResult: Encodable {
         feedbacks.filter { $0.type == .inline }
     }
 
-    mutating func addFeedback(id: UUID = UUID(), detailText: String, credits: Double, type: FeedbackType, file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) {
+    mutating func addFeedback(id: UUID = UUID(), detailText: String, credits: Double, type: FeedbackType,
+                              file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) {
         feedbacks.append(AssessmentFeedback(id: id, detailText: detailText, credits: credits, type: type, file: file, lines: lines, columns: columns))
     }
 

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -77,12 +77,12 @@ class CodeEditorViewModel: ObservableObject {
                 inlineHighlights[file.path]?.append(HighlightedRange(id: feedbackId.uuidString,
                                                                      range: selectedSection,
                                                                      color: UIColor.systemYellow,
-                                                                     cornerRadius: 10))
+                                                                     cornerRadius: 8))
             } else {
                 inlineHighlights[file.path] = [HighlightedRange(id: feedbackId.uuidString,
                                                                 range: selectedSection,
                                                                 color: UIColor.systemYellow,
-                                                                cornerRadius: 10)]
+                                                                cornerRadius: 8)]
             }
         }
     }

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -21,11 +21,11 @@ class CodeEditorViewModel: ObservableObject {
 
     var selectedSectionParsed: (NSRange, NSRange?)? {
         if let selectedFile = selectedFile, let selectedSection = selectedSection, let lines = selectedFile.lines {
-            let fromLine = (lines.firstIndex(where: { $0.contains(selectedSection.location) }) ?? -1) + 1
-            let toLine = (lines.firstIndex(where: { $0.contains(selectedSection.location + selectedSection.length) }) ?? -1) + 1
+            let fromLine = (lines.firstIndex { $0.contains(selectedSection.location) } ?? -1) + 1
+            let toLine = (lines.firstIndex { $0.contains(selectedSection.location + selectedSection.length) } ?? -1) + 1
             let lineRange = NSRange(location: fromLine, length: toLine - fromLine)
 
-            if fromLine == toLine {
+            if (fromLine == toLine) && (fromLine != 0) {
                 let fromColumn = selectedSection.location - lines[fromLine - 1].location
                 let toColumn = (selectedSection.location + selectedSection.length) - lines[toLine - 1].location
                 let columnRange = NSRange(location: fromColumn, length: toColumn - fromColumn)

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -15,7 +15,7 @@ class CodeEditorViewModel: ObservableObject {
     @Published var selectedFile: Node?
     @Published var editorFontSize = CGFloat(14) // Default font size
     @Published var currentlySelecting: Bool = false
-    @Published var selectedSection: NSRange? // First Range = selected Lines, Second Range = columns iff single line
+    @Published var selectedSection: NSRange?
     @Published var inlineHighlights: [String: [HighlightedRange]] = [:]
     @Published var showAddFeedback: Bool = false
 
@@ -26,7 +26,7 @@ class CodeEditorViewModel: ObservableObject {
             let lineRange = NSRange(location: fromLine, length: toLine - fromLine)
 
             if (fromLine == toLine) && (fromLine != 0) {
-                let fromColumn = selectedSection.location - lines[fromLine - 1].location
+                let fromColumn = (selectedSection.location - lines[fromLine - 1].location) + 1
                 let toColumn = (selectedSection.location + selectedSection.length) - lines[toLine - 1].location
                 let columnRange = NSRange(location: fromColumn, length: toColumn - fromColumn)
                 return (lineRange, columnRange)

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -15,9 +15,26 @@ class CodeEditorViewModel: ObservableObject {
     @Published var selectedFile: Node?
     @Published var editorFontSize = CGFloat(14) // Default font size
     @Published var currentlySelecting: Bool = false
-    @Published var selectedLineNumber: Int?
+    @Published var selectedSection: NSRange? // First Range = selected Lines, Second Range = columns iff single line
     @Published var inlineHighlights: [String: [HighlightedRange]] = [:]
     @Published var showAddFeedback: Bool = false
+
+    var selectedSectionParsed: (NSRange, NSRange?)? {
+        if let selectedFile = selectedFile, let selectedSection = selectedSection, let lines = selectedFile.lines {
+            let fromLine = (lines.firstIndex(where: { $0.contains(selectedSection.location) }) ?? -1) + 1
+            let toLine = (lines.firstIndex(where: { $0.contains(selectedSection.location + selectedSection.length) }) ?? -1) + 1
+            let lineRange = NSRange(location: fromLine, length: toLine - fromLine)
+
+            if fromLine == toLine {
+                let fromColumn = selectedSection.location - lines[fromLine - 1].location
+                let toColumn = (selectedSection.location + selectedSection.length) - lines[toLine - 1].location
+                let columnRange = NSRange(location: fromColumn, length: toColumn - fromColumn)
+                return (lineRange, columnRange)
+            }
+            return (lineRange, nil)
+        }
+        return nil
+    }
 
     func incrementFontSize() {
         editorFontSize += 1
@@ -55,15 +72,15 @@ class CodeEditorViewModel: ObservableObject {
     }
 
     func addInlineHighlight(feedbackId: UUID) {
-        if let file = selectedFile, let lineReference = selectedLineNumber, let lines = file.lines {
+        if let file = selectedFile, let selectedSection = selectedSection {
             if (inlineHighlights.contains { $0.key == file.path }) {
                 inlineHighlights[file.path]?.append(HighlightedRange(id: feedbackId.uuidString,
-                                                                     range: lines[lineReference - 1],
+                                                                     range: selectedSection,
                                                                      color: UIColor.systemYellow,
                                                                      cornerRadius: 10))
             } else {
                 inlineHighlights[file.path] = [HighlightedRange(id: feedbackId.uuidString,
-                                                                range: lines[lineReference - 1],
+                                                                range: selectedSection,
                                                                 color: UIColor.systemYellow,
                                                                 cornerRadius: 10)]
             }

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -34,6 +34,7 @@ struct CodeView: UIViewControllerRepresentable {
             self.parent = parent
         }
 
+        @MainActor
         func textViewDidChangeSelection(_ textView: TextView) {
             if textView.selectedRange.length > 0 {
                 parent.cvm.currentlySelecting = true

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -37,9 +37,7 @@ struct CodeView: UIViewControllerRepresentable {
         func textViewDidChangeSelection(_ textView: TextView) {
             if textView.selectedRange.length > 0 {
                 parent.cvm.currentlySelecting = true
-                parent.cvm.selectedLineNumber = (parent.cvm.selectedFile?.lines?.firstIndex {
-                    $0.contains(textView.selectedRange.location)
-                } ?? 0) + 1
+                parent.cvm.selectedSection = textView.selectedRange
             } else {
                 parent.cvm.currentlySelecting = false
             }

--- a/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
@@ -88,7 +88,8 @@ struct EditFeedbackView: View {
                                          credits: score,
                                          type: type,
                                          file: cvm.selectedFile,
-                                         line: cvm.selectedLineNumber)
+                                         lines: cvm.selectedSectionParsed?.0,
+                                         columns: cvm.selectedSectionParsed?.1)
                 cvm.addInlineHighlight(feedbackId: id)
             } else {
                 avm.feedback.addFeedback(detailText: feedbackText, credits: score, type: type)


### PR DESCRIPTION
- Instead of always highlighting the complete first line of the selected text, the complete selection is now highlighted
- If multiple lines are selected, the related line numbers are stored as reference 
- If a single line is selected, the related line number and column range are stored as reference

![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2022-12-04 at 19 00 38](https://user-images.githubusercontent.com/79016456/205507568-6b37a94e-00d2-40cb-adef-765da19c012d.png)
