### PR TITLE
add support for uml diagram in dark mode

### DIFF
--- a/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
+++ b/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
@@ -15,10 +15,17 @@ protocol ProblemStatementPart {
 }
 
 struct ProblemStatementPlantUML: ProblemStatementPart {
+    let colorScheme: ColorScheme
     let text: String
     var url: URL? {
         var url = URL(string: "https://artemis-staging.ase.in.tum.de/api/plantuml/png")
-        url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text)])
+
+        if colorScheme == .light {
+            url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text), URLQueryItem(name: "useDarkTheme", value: "false")])
+        } else {
+            url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text), URLQueryItem(name: "useDarkTheme", value: "true")])
+        }
+
         return url
     }
 }
@@ -31,7 +38,7 @@ class ProblemStatementCellViewModel: ObservableObject {
 
     @Published var problemStatementParts: [any ProblemStatementPart] = []
 
-    func convertProblemStatement(problemStatement: String) {
+    func convertProblemStatement(problemStatement: String, colorScheme: ColorScheme) {
         var index = problemStatement.startIndex
         // as long as problemstatemnt is not done
         while index < problemStatement.endIndex {
@@ -51,8 +58,8 @@ class ProblemStatementCellViewModel: ObservableObject {
 
             // Append plantuml
             substring = String(problemStatement[rangeStart.lowerBound...rangeEnd.upperBound])
-            substring = replaceTestsColor(substring)
-            problemStatementParts.append(ProblemStatementPlantUML(text: substring))
+            substring = replaceTestsColor(substring, colorScheme)
+            problemStatementParts.append(ProblemStatementPlantUML(colorScheme: colorScheme, text: substring))
 
             index = problemStatement.index(rangeEnd.upperBound, offsetBy: 1)
         }
@@ -64,9 +71,12 @@ class ProblemStatementCellViewModel: ObservableObject {
             .replacingOccurrences(of: "](.*())", with: "", options: .regularExpression) // to remove tests
     }
 
-    func replaceTestsColor(_ problemStatement: String) -> String {
+    func replaceTestsColor(_ problemStatement: String, _ colorSchemeVariable: ColorScheme) -> String {
         return problemStatement
-            .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: "black", options: .regularExpression) // replace test color by red (or green)
+                .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: colorSchemeVariable == .light ? "black" : "white", options: .regularExpression)
+
+        // return problemStatement
+            // .replacingOccurrences(of: "testsColor\\([A-z]+\\)", with: "black", options: .regularExpression) // replace test color by red (or green)
             // .replacingOccurrences(of: "testsColor(testAttributes[.*])", with: "", options: .regularExpression)
             // .replacingOccurrences(of: "testsColor(testMethods[.*])", with: "", options: .regularExpression)
             // .replacingOccurrences(of: "testsColor(testClass[.*])", with: "", options: .regularExpression)

--- a/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
+++ b/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
@@ -19,13 +19,7 @@ struct ProblemStatementPlantUML: ProblemStatementPart {
     let text: String
     var url: URL? {
         var url = URL(string: "https://artemis-staging.ase.in.tum.de/api/plantuml/png")
-
-        if colorScheme == .light {
-            url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text), URLQueryItem(name: "useDarkTheme", value: "false")])
-        } else {
-            url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text), URLQueryItem(name: "useDarkTheme", value: "true")])
-        }
-
+        url?.append(queryItems: [URLQueryItem(name: "plantuml", value: text), URLQueryItem(name: "useDarkTheme", value: String(colorScheme != .light))])
         return url
     }
 }

--- a/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
@@ -10,6 +10,7 @@ import Foundation
 import MarkdownUI
 
 struct ProblemStatementCellView: View {
+    @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var assessment: AssessmentViewModel
 
     @StateObject var vm = ProblemStatementCellViewModel()
@@ -35,7 +36,9 @@ struct ProblemStatementCellView: View {
         }
         .padding()
         .onAppear {
-            vm.convertProblemStatement(problemStatement: assessment.submission?.participation.exercise.problemStatement ?? "")
+            vm.convertProblemStatement(
+                problemStatement: assessment.submission?.participation.exercise.problemStatement ?? "",
+                colorScheme: colorScheme)
         }
     }
 }


### PR DESCRIPTION
This PR adds support for UML diagrams in dark mode based on system settings.

![Bildschirm­foto 2022-12-05 um 22 12 05](https://user-images.githubusercontent.com/116847304/205744346-ccba7321-e2c1-4b48-a169-881037c71f70.png)

![Bildschirm­foto 2022-12-05 um 22 12 34](https://user-images.githubusercontent.com/116847304/205744365-6faa3c7d-c1aa-4ed7-9d59-9a8b3843b34b.png)
