### PR TITLE
Even Better Authentication View

### DIFF
--- a/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
@@ -13,7 +13,7 @@ class AuthenticationViewModel: ObservableObject {
     /// Updating it will update the RESTController base URL and will save it in the User Defaults
     @Published var serverURL: String {
         didSet {
-            guard let url = URL(string: serverURL) else {
+            guard let url = generateURL(serverURL: serverURL) else {
                 return
             }
             UserDefaults.standard.set(serverURL, forKey: "serverURL")
@@ -25,6 +25,20 @@ class AuthenticationViewModel: ObservableObject {
             }
         }
     }
+    
+    var validURL: Bool {
+        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        if let match = detector.firstMatch(in: serverURL, options: [], range: NSRange(location: 0, length: serverURL.utf16.count)) {
+            return match.range.length == serverURL.utf16.count
+        } else {
+            return false
+        }
+    }
+    
+    var loginDisabled: Bool {
+        !validURL || username.count < 1 || password.count < 1
+    }
+    
     @Published var username: String = stagingUser ?? ""
     @Published var password: String = stagingPassword ?? ""
     @Published var rememberMe: Bool = true
@@ -40,7 +54,7 @@ class AuthenticationViewModel: ObservableObject {
 
     init(serverURL: String) {
         self.serverURL = serverURL
-        if let serverURL = URL(string: serverURL) {
+        if let serverURL = generateURL(serverURL: serverURL) {
             RESTController.shared = RESTController(baseURL: serverURL)
             restControllerInitialized = true
             Authentication.shared = Authentication(for: serverURL)
@@ -51,6 +65,20 @@ class AuthenticationViewModel: ObservableObject {
             observeAuthenticationStatus()
             Authentication.shared.checkAuth()
         }
+    }
+    
+    private func generateURL(serverURL: String) -> URL? {
+        guard let url = URL(string: serverURL) else { return nil }
+        return cleanURL(url: url)
+    }
+    
+    private func cleanURL(url: URL) -> URL? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        guard let components else { return nil }
+        var newComponents = URLComponents()
+        newComponents.scheme = components.scheme
+        newComponents.host = components.host
+        return newComponents.url
     }
 
     convenience init() {

--- a/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
+++ b/Themis/ViewModels/Authentication/AuthenticationViewModel.swift
@@ -27,7 +27,7 @@ class AuthenticationViewModel: ObservableObject {
     }
     
     var validURL: Bool {
-        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return false }
         if let match = detector.firstMatch(in: serverURL, options: [], range: NSRange(location: 0, length: serverURL.utf16.count)) {
             return match.range.length == serverURL.utf16.count
         } else {


### PR DESCRIPTION
The Authentication View now checks if the URL is valid without being too restrictive. It checks for simple mistakes like https:/artemis.de (one slash). Furthermore:
**https://artemis-staging.ase.in.tum.de/
https://artemis-staging.ase.in.tum.de**
The first link with the slash as last character breaks our API, because all the Rest Calls are translated to ....tum.de//api/....
Therefore the url is now cleaned first. 
(This Method might be to restrictive and we might need to change that later on
but for the Artemis Staging and Test server and TUM Artemis Server this _should_ not fail)

Also The Textfield now has an little button to toggle the secure field to a plain textfield.

**Be aware** that the Screenrecording removed the _dots_ of the secure textfield but in the app everything is looking like before.

https://user-images.githubusercontent.com/16856573/205918509-64d09b32-7ee8-44c7-8fe2-fe314570c955.MP4


