### PR TITLE
Loading feedbacks from Artemis

### DIFF
--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -5,6 +5,8 @@
 //  Created by Andreas Cselovszky on 14.11.22.
 //
 
+// swiftlint:disable line_length
+
 import Foundation
 
 enum FeedbackType {

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -105,7 +105,7 @@ struct AssessmentFeedback: Identifiable {
     }
 }
 
-// make feedback encodable to send to artemis
+// send to artemis
 extension AssessmentFeedback: Encodable {
     enum EncodingKeys: CodingKey {
         case text
@@ -121,7 +121,7 @@ extension AssessmentFeedback: Encodable {
     }
 }
 
-// make feedback decodable to receive feedbacks from artemis
+// receive feedbacks from artemis
 extension AssessmentFeedback: Decodable {
     enum DecodingKeys: String, CodingKey {
         case text

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -30,15 +30,23 @@ struct AssessmentResult: Encodable {
     }
 
     var generalFeedback: [AssessmentFeedback] {
-        feedbacks.filter { $0.type == .general }
-    }
-    var inlineFeedback: [AssessmentFeedback] {
-        feedbacks.filter { $0.type == .inline }
+        return feedbacks
+            .filter { $0.type == .general }
+            .sorted { $0.assessmentType == .MANUAL && $1.assessmentType == .AUTOMATIC }
+            .sorted(by: >)
     }
 
-    mutating func addFeedback(id: UUID = UUID(), detailText: String, credits: Double, type: FeedbackType,
-                              file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) {
-        feedbacks.append(AssessmentFeedback(id: id, detailText: detailText, credits: credits, type: type, file: file, lines: lines, columns: columns))
+    var inlineFeedback: [AssessmentFeedback] {
+        feedbacks
+            .filter { $0.type == .inline }
+            .sorted(by: >)
+    }
+
+    mutating func addFeedback(detailText: String, credits: Double, type: FeedbackType, file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) -> AssessmentFeedback {
+        let text = makeText(file: file, lines: lines, columns: columns)
+        let feedback = AssessmentFeedback(text: text, detailText: detailText, credits: credits, type: type, file: file)
+        feedbacks.append(feedback)
+        return feedback
     }
 
     mutating func deleteFeedback(id: UUID) {
@@ -51,16 +59,13 @@ struct AssessmentResult: Encodable {
         }
         feedbacks[index].updateFeedback(detailText: detailText, credits: credits)
     }
-}
 
-struct AssessmentFeedback: Encodable, Identifiable {
-    let id: UUID
-    var text: String {
+    func makeText(file: Node?, lines: NSRange?, columns: NSRange?) -> String? {
         guard let file = file, let lines = lines else {
-            return ""
+            return nil
         }
         if lines.location == 0 {
-            return ""
+            return nil
         }
         guard let columns = columns else {
             return file.name + " at Lines: \(lines.location)-\(lines.location + lines.length)"
@@ -69,32 +74,74 @@ struct AssessmentFeedback: Encodable, Identifiable {
             return file.name + " at Line: \(lines.location) Col: \(columns.location)"
         }
         return file.name + " at Line: \(lines.location) Col: \(columns.location)-\(columns.location + columns.length)"
-    } /// max length = 500
-    var detailText: String /// max length = 5000
+    }
+}
+
+struct AssessmentFeedback: Identifiable {
+    // attributes from artemis
+    let id: UUID = UUID()
+    let created: Date = Date()
+    var text: String? /// max length = 500
+    var detailText: String? /// max length = 5000
     var credits: Double /// score of element
+    var assessmentType: AssessmentType?
 
-    let type: FeedbackType
+    // custom utility attributes
+    var type: FeedbackType
     var file: Node?
-    var lines: NSRange?
-    var columns: NSRange?
 
-    enum CodingKeys: CodingKey {
+    mutating func updateFeedback(detailText: String, credits: Double) {
+        self.detailText = detailText
+        self.credits = credits
+    }
+}
+
+// make feedback encodable to send to artemis
+extension AssessmentFeedback: Encodable {
+    enum EncodingKeys: CodingKey {
         case text
         case detailText
         case credits
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: EncodingKeys.self)
         try container.encode(text, forKey: .text)
         try container.encode(detailText, forKey: .detailText)
         try container.encode(credits, forKey: .credits)
     }
+}
 
-    mutating func updateFeedback(detailText: String, credits: Double) {
-        self.detailText = detailText
-        self.credits = credits
+// make feedback decodable to receive feedbacks from artemis
+extension AssessmentFeedback: Decodable {
+    enum DecodingKeys: String, CodingKey {
+        case text
+        case detailText
+        case credits
+        case assessmentType = "type"
     }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: DecodingKeys.self)
+        text = try? values.decode(String?.self, forKey: .text)
+        detailText = try? values.decode(String?.self, forKey: .detailText)
+        credits = try values.decode(Double?.self, forKey: .credits) ?? 0.0
+        type = text?.contains("at Line:") ?? false ? .inline : .general
+        // TODO: find a way to distinguish between automatic and manual feedback when fetching feedback for a specific submission
+        assessmentType = try? values.decode(AssessmentType?.self, forKey: .assessmentType) ?? .MANUAL
+    }
+}
+
+extension AssessmentFeedback: Comparable {
+    static func < (lhs: AssessmentFeedback, rhs: AssessmentFeedback) -> Bool {
+        lhs.created < rhs.created
+    }
+}
+
+enum AssessmentType: String, Codable {
+    case AUTOMATIC
+    case SEMI_AUTOMATIC
+    case MANUAL
 }
 
 enum FeedbackVisibility: String, Codable {

--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -18,7 +18,17 @@ struct AssessmentResult: Encodable {
     var score: Double {
         feedbacks.reduce(0) { $0 + $1.credits }
     }
-    var feedbacks: [AssessmentFeedback]
+
+    private var _feedbacks: [AssessmentFeedback] = []
+
+    var feedbacks: [AssessmentFeedback] {
+        get {
+            _feedbacks
+        }
+        set(new) {
+            _feedbacks = new.sorted(by: >).sorted { $0.assessmentType == .MANUAL && $1.assessmentType == .AUTOMATIC }
+        }
+    }
 
     enum CodingKeys: CodingKey {
         case score
@@ -34,14 +44,11 @@ struct AssessmentResult: Encodable {
     var generalFeedback: [AssessmentFeedback] {
         return feedbacks
             .filter { $0.type == .general }
-            .sorted { $0.assessmentType == .MANUAL && $1.assessmentType == .AUTOMATIC }
-            .sorted(by: >)
     }
 
     var inlineFeedback: [AssessmentFeedback] {
         feedbacks
             .filter { $0.type == .inline }
-            .sorted(by: >)
     }
 
     mutating func addFeedback(detailText: String, credits: Double, type: FeedbackType, file: Node? = nil, lines: NSRange? = nil, columns: NSRange? = nil) -> AssessmentFeedback {

--- a/Themis/Models/Submission.swift
+++ b/Themis/Models/Submission.swift
@@ -55,7 +55,13 @@ struct ExerciseOfSubmission: Codable {
 struct SubmissionForAssessment: Codable {
     let id: Int
     let participation: ParticipationForAssessment
-    let feedbacks: [ArtemisFeedback]?
+    let feedbacks: [AssessmentFeedback]?
+    let results: [SavedAssessmentResults]?
+}
+
+struct SavedAssessmentResults: Codable {
+    let score: Double?
+    let feedbacks: [AssessmentFeedback]
 }
 
 struct GradingCriterion: Codable, Identifiable {
@@ -73,28 +79,14 @@ struct GradingInstruction: Codable, Identifiable {
     var usageCount: Int
 }
 
-enum AssessmentType: String, Codable {
-    case automatic = "AUTOMATIC"
-    case semi_automatic = "SEMI_AUTOMATIC"
-    case manual = "MANUAL"
-}
-
 struct ParticipationResult: Codable {
     let submission: SubmissionFromResult
-    let feedbacks: [ArtemisFeedback]
+    let feedbacks: [AssessmentFeedback]
     let participation: ParticipationForAssessment
 }
 
 struct SubmissionFromResult: Codable {
     let id: Int
-}
-
-struct ArtemisFeedback: Codable {
-    let text: String
-    let detailText: String?
-    let credits: Double
-    let positive: Bool
-    let type: AssessmentType
 }
 
 extension ArtemisAPI {
@@ -140,7 +132,8 @@ extension ArtemisAPI {
         return SubmissionForAssessment(
             id: pr.submission.id,
             participation: pr.participation,
-            feedbacks: pr.feedbacks
+            feedbacks: pr.feedbacks,
+            results: nil
         )
     }
 }

--- a/Themis/ViewModels/Assessment/AssessmentViewModel.swift
+++ b/Themis/ViewModels/Assessment/AssessmentViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 
 class AssessmentViewModel: ObservableObject {
     @Published var submission: SubmissionForAssessment?
-    @Published var feedback: AssessmentResult = AssessmentResult(feedbacks: [])
+    @Published var feedback: AssessmentResult = AssessmentResult()
     @Published var showSubmission: Bool = false
 
     let readOnly: Bool
@@ -48,7 +48,7 @@ class AssessmentViewModel: ObservableObject {
             print(error)
         }
         self.submission = nil
-        self.feedback = AssessmentResult(feedbacks: [])
+        self.feedback = AssessmentResult()
     }
 
     @MainActor

--- a/Themis/ViewModels/Assessment/AssessmentViewModel.swift
+++ b/Themis/ViewModels/Assessment/AssessmentViewModel.swift
@@ -17,6 +17,7 @@ class AssessmentViewModel: ObservableObject {
     func initRandomSubmission(exerciseId: Int) async {
         do {
             self.submission = try await ArtemisAPI.getRandomSubmissionForAssessment(exerciseId: exerciseId)
+            feedback.feedbacks = submission?.results?.last?.feedbacks ?? []
             self.showSubmission = true
         } catch {
             print(error)
@@ -28,8 +29,10 @@ class AssessmentViewModel: ObservableObject {
         do {
             if readOnly {
                 self.submission = try await ArtemisAPI.getSubmissionForReadOnly(participationId: id)
+                feedback.feedbacks = submission?.feedbacks ?? []
             } else {
                 self.submission = try await ArtemisAPI.getSubmissionForAssessment(submissionId: id)
+                feedback.feedbacks = submission?.results?.last?.feedbacks ?? []
             }
             self.showSubmission = true
         } catch {

--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -73,8 +73,8 @@ struct AssessmentView: View {
                     .confirmationDialog("Cancel Assessment", isPresented: $showCancelDialog) {
                         Button("Save") {
                             Task {
-                                if let id = vm.submission?.id {
-                                    await vm.sendAssessment(participationId: id, submit: false)
+                                if let pId = vm.submission?.participation.id {
+                                    await vm.sendAssessment(participationId: pId, submit: false)
                                     presentationMode.wrappedValue.dismiss()
                                 }
                             }

--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable line_length
-
 import SwiftUI
 
 struct AssessmentView: View {
@@ -93,7 +91,11 @@ struct AssessmentView: View {
                             }
                         }
                     } message: {
-                        Text("Either discard the assessment and release the lock (recommended) or keep the lock and save the assessment without submitting it.")
+                        Text("""
+                             Either discard the assessment \
+                             and release the lock (recommended) \
+                             or keep the lock and save the assessment without submitting it.
+                             """)
                     }
                 }
             }

--- a/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
@@ -42,7 +42,7 @@ struct EditFeedbackView: View {
                 } label: {
                     Text("Save")
                 }.font(.title)
-                 .disabled(feedbackText.isEmpty)
+                    .disabled(feedbackText.isEmpty)
             }
             HStack {
                 TextField("Enter your feedback here", text: $feedbackText, axis: .vertical)
@@ -81,17 +81,16 @@ struct EditFeedbackView: View {
             avm.feedback.updateFeedback(id: feedback.id, detailText: feedbackText, credits: score)
         } else {
             if type == .inline {
-                let id = UUID()
-                avm.feedback.addFeedback(id: id,
-                                         detailText: feedbackText,
-                                         credits: score,
-                                         type: type,
-                                         file: cvm.selectedFile,
-                                         lines: cvm.selectedSectionParsed?.0,
-                                         columns: cvm.selectedSectionParsed?.1)
-                cvm.addInlineHighlight(feedbackId: id)
+                let feedback = avm.feedback.addFeedback(
+                    detailText: feedbackText,
+                    credits: score,
+                    type: type,
+                    file: cvm.selectedFile,
+                    lines: cvm.selectedSectionParsed?.0,
+                    columns: cvm.selectedSectionParsed?.1)
+                cvm.addInlineHighlight(feedbackId: feedback.id)
             } else {
-                avm.feedback.addFeedback(detailText: feedbackText, credits: score, type: type)
+                _ = avm.feedback.addFeedback(detailText: feedbackText, credits: score, type: type)
             }
         }
     }
@@ -100,7 +99,7 @@ struct EditFeedbackView: View {
         guard let feedback = feedback else {
             return
         }
-        self.feedbackText = feedback.detailText
+        self.feedbackText = feedback.detailText ?? ""
         self.score = feedback.credits
     }
 }

--- a/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
@@ -14,6 +14,7 @@ struct FeedbackCellView: View {
     @EnvironmentObject var cvm: CodeEditorViewModel
 
     let feedback: AssessmentFeedback
+    var editingDisabled: Bool { assessment.readOnly || feedback.assessmentType == .AUTOMATIC }
 
     @State var showEditFeedback = false
     var feedbackColor: Color {
@@ -29,7 +30,7 @@ struct FeedbackCellView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text(feedback.text.isEmpty ? "Feedback" : feedback.text)
+                Text(feedback.text ?? "Feedback")
                 Spacer()
                 Button {
                     showEditFeedback = true
@@ -38,7 +39,7 @@ struct FeedbackCellView: View {
                         .resizable()
                         .frame(width: 15, height: 15)
                 }
-                .disabled(assessment.readOnly)
+                .disabled(editingDisabled)
                 .buttonStyle(.borderless)
                 .font(.caption)
                 Button(role: .destructive) {
@@ -49,14 +50,14 @@ struct FeedbackCellView: View {
                         .resizable()
                         .frame(width: 15, height: 15)
                 }
-                .disabled(assessment.readOnly)
+                .disabled(editingDisabled)
                 .buttonStyle(.borderless)
                 .font(.caption)
             }
             Divider()
                 .frame(maxWidth: .infinity)
             HStack {
-                Text(feedback.detailText)
+                Text(feedback.detailText ?? "")
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text(String(format: "%.1f", feedback.credits))
                     .foregroundColor(feedbackColor)


### PR DESCRIPTION
This pr enables loading the feedback that is saved in Artemis (tests and previous saved feedback) to be loaded into the assessment view. The feedback is ordered by creation date and wether it is manual or automatic feedback. Also deleting automatic feedback is prevented (except in reassessment because of Artemis api). 
Another already known bug I will look into fixing in the future: after assessment, Artemis will display the test results as if they are from the Tutor.

I will also try to clean up the code around the models in the future, as its getting really messy (thanks to Artemis API).