### PR TITLE
Add focus to TextFields in AuthenticationView

### DIFF
--- a/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/EditFeedbackView.swift
@@ -46,6 +46,7 @@ struct EditFeedbackView: View {
             }
             HStack {
                 TextField("Enter your feedback here", text: $feedbackText, axis: .vertical)
+                    .submitLabel(.return)
                     .lineLimit(10...40)
                     .padding()
                     .overlay(RoundedRectangle(cornerRadius: 20)

--- a/Themis/Views/Submissions/SubmissionSearchView.swift
+++ b/Themis/Views/Submissions/SubmissionSearchView.swift
@@ -48,6 +48,7 @@ extension SubmissionSearchView {
                 .foregroundColor(Color(.label))
                 .frame(width: 20, height: 20)
             TextField("Search for a submission", text: $search)
+                .submitLabel(.search)
         }
         .padding()
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))


### PR DESCRIPTION
When entering the information in AuthenticationView the the focus switches to the next TextField when submitting.
When the password is submitted, the view automatically tries to authenticate without having to press the button.