### PR TITLE
Readd highlighting for InlineFeedbacks

### DIFF
--- a/CodeEditor/Sources/CodeEditor/CodeEditor.swift
+++ b/CodeEditor/Sources/CodeEditor/CodeEditor.swift
@@ -243,7 +243,8 @@ public struct CodeEditor: View {
                 highlightedRanges: [HighlightedRange] = [],
                 dragSelection: Binding<Range<Int>?>? = nil,
                 line: Binding<Line?>?       = nil,
-                showAddFeedback: Binding<Bool>) {
+                showAddFeedback: Binding<Bool>,
+                selectedSection: Binding<NSRange?>) {
         self.source      = source
         self.selection   = selection
         self.fontSize    = fontSize
@@ -260,6 +261,7 @@ public struct CodeEditor: View {
         self.dragSelection = dragSelection
         self.line = line
         self.showAddFeedback = showAddFeedback
+        self.selectedSection = selectedSection
     }
 
     /**
@@ -299,7 +301,8 @@ public struct CodeEditor: View {
                 highlightedRanges: [HighlightedRange] = [],
                 dragSelection: Binding<Range<Int>?>? = nil,
                 line: Binding<Line?>?       = nil,
-                showAddFeedback: Binding<Bool>) {
+                showAddFeedback: Binding<Bool>,
+                selectedSection: Binding<NSRange?>) {
         assert(!flags.contains(.editable), "Editing requires a Binding")
         self.init(source: .constant(source),
                   selection: selection,
@@ -313,7 +316,8 @@ public struct CodeEditor: View {
                   highlightedRanges: highlightedRanges,
                   dragSelection: dragSelection,
                   line: line,
-                  showAddFeedback: showAddFeedback)
+                  showAddFeedback: showAddFeedback,
+                  selectedSection: selectedSection)
     }
 
     private var source: Binding<String>
@@ -330,6 +334,7 @@ public struct CodeEditor: View {
     private var dragSelection: Binding<Range<Int>?>?
     private var line: Binding<Line?>?
     private var showAddFeedback: Binding<Bool>
+    private var selectedSection: Binding<NSRange?>
 
     public var body: some View {
         UXCodeTextViewRepresentable(source: source,
@@ -345,6 +350,7 @@ public struct CodeEditor: View {
                                     highlightedRanges: highlightedRanges,
                                     dragSelection: dragSelection,
                                     line: line,
-                                    showAddFeedback: showAddFeedback)
+                                    showAddFeedback: showAddFeedback,
+                                    selectedSection: selectedSection)
     }
 }

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
@@ -275,7 +275,7 @@ final class UXCodeTextView: UXTextView, HighlightDelegate {
                 self.textStorage.addAttribute(
                     NSAttributedString.Key.backgroundColor,
                     value: hRange.color,
-                    range: hRange.range.makeSafeFor(text)
+                    range: hRange.range
                 )
             }
             if let dragSelection {

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -169,10 +169,12 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
 
         public func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
             var additionalActions: [UIMenuElement] = []
-            let feedbackAction = UIAction(title: "Feedback") { _ in
-                self.parent.showAddFeedback.wrappedValue.toggle()
+            if range.length > 0 {
+                let feedbackAction = UIAction(title: "Feedback") { _ in
+                    self.parent.showAddFeedback.wrappedValue.toggle()
+                }
+                additionalActions.append(feedbackAction)
             }
-            additionalActions.append(feedbackAction)
             return UIMenu(children: additionalActions + suggestedActions)
         }
 
@@ -285,6 +287,7 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
         textView.isEditable   = flags.contains(.editable)
         textView.isSelectable = flags.contains(.selectable)
         textView.backgroundColor = flags.contains(.blackBackground) ? UIColor.black : UIColor.white
+        textView.highlightedRanges = highlightedRanges
     }
 
 #if os(macOS)

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -59,7 +59,8 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
                 highlightedRanges: [HighlightedRange],
                 dragSelection: Binding<Range<Int>?>?,
                 line: Binding<Line?>?,
-                showAddFeedback: Binding<Bool>) {
+                showAddFeedback: Binding<Bool>,
+                selectedSection: Binding<NSRange?>) {
         self.source      = source
         self.selection = selection
         self.fontSize    = fontSize
@@ -74,6 +75,7 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
         self.dragSelection = dragSelection
         self.line = line
         self.showAddFeedback = showAddFeedback
+        self.selectedSection = selectedSection
     }
 
     private var source: Binding<String>
@@ -90,6 +92,7 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
     private var dragSelection: Binding<Range<Int>?>?
     private var line: Binding<Line?>?
     private var showAddFeedback: Binding<Bool>
+    private var selectedSection: Binding<NSRange?>
 
     // The inner `value` is true, exactly when execution is inside
     // the `updateTextView(_:)` method. The `Coordinator` can use this
@@ -181,6 +184,10 @@ struct UXCodeTextViewRepresentable: UXViewRepresentable {
             // (Changing a `State` during a `View` update is not permitted).
             guard !parent.isCurrentlyUpdatingView.value else {
                 return
+            }
+            // avoid empty references for inline highlights
+            if textView.selectedRange.length > 0 {
+                parent.selectedSection.wrappedValue = textView.selectedRange
             }
 
             guard let selection = parent.selection else {

--- a/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
@@ -21,7 +21,7 @@ struct CodeEditorView: View {
                             .frame(width: showFileTree ? 0 : 40)
                         TabsView()
                     }
-                    CodeView(
+                    CodeViewSelect(
                         cvm: cvm, file: file,
                         fontSize: $cvm.editorFontSize,
                         onOpenFeedback: openFeedbackSheet

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -48,7 +48,7 @@ struct CodeView: View {
 
     var editorFlags: CodeEditor.Flags {
         if colorScheme == .dark {
-            return .blackBackground
+            return [.selectable, .blackBackground]
         } else {
             return .selectable
         }
@@ -90,7 +90,7 @@ struct CodeView: View {
 
     var editorFlags: CodeEditor.Flags {
         if colorScheme == .dark {
-            return .blackBackground
+            return [.selectable, .blackBackground]
         } else {
             return .selectable
         }

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -17,7 +17,7 @@ struct CodeView: View {
                        theme: theme,
                        fontSize: $fontSize,
                        flags: editorFlags,
-                       highlightedRanges: mockHighlights,
+                       highlightedRanges: cvm.inlineHighlights[file.path] ?? [],
                        dragSelection: $dragSelection,
                        line: $line,
                        showAddFeedback: $cvm.showAddFeedback,
@@ -44,11 +44,6 @@ struct CodeView: View {
             dragSelection = nil
             line = nil
         })
-    }
-
-    var mockHighlights: [HighlightedRange] {
-        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow, cornerRadius: 10),
-                HighlightedRange(range: NSRange(location: 30, length: 10), color: UIColor.red)]
     }
 
     var editorFlags: CodeEditor.Flags {
@@ -85,17 +80,12 @@ struct CodeView: View {
                        theme: theme,
                        fontSize: $fontSize,
                        flags: editorFlags,
-                       highlightedRanges: mockHighlights,
+                       highlightedRanges: cvm.inlineHighlights[file.path] ?? [],
                        dragSelection: $dragSelection,
                        line: $line,
                        showAddFeedback: $cvm.showAddFeedback,
                        selectedSection: $cvm.selectedSection)
         }
-    }
-
-    var mockHighlights: [HighlightedRange] {
-        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow),
-                HighlightedRange(range: NSRange(location: 30, length: 10), color: UIColor.red)]
     }
 
     var editorFlags: CodeEditor.Flags {

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -20,7 +20,8 @@ struct CodeView: View {
                        highlightedRanges: mockHighlights,
                        dragSelection: $dragSelection,
                        line: $line,
-                       showAddFeedback: $cvm.showAddFeedback)
+                       showAddFeedback: $cvm.showAddFeedback,
+                       selectedSection: $cvm.selectedSection)
             if let line {
                 DrawingShape(points: line.points)
                     .stroke(line.color, style: StrokeStyle(lineWidth: line.lineWidth, lineCap: .round, lineJoin: .round))
@@ -46,7 +47,7 @@ struct CodeView: View {
     }
 
     var mockHighlights: [HighlightedRange] {
-        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow),
+        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow, cornerRadius: 10),
                 HighlightedRange(range: NSRange(location: 30, length: 10), color: UIColor.red)]
     }
 
@@ -68,47 +69,48 @@ struct CodeView: View {
 }
 
 /// used for testing editmenu
-// struct CodeViewSelect: View {
-//    @Environment(\.colorScheme) var colorScheme
-//    @ObservedObject var cvm: CodeEditorViewModel
-//    @ObservedObject var file: Node
-//    @Binding var fontSize: CGFloat
-//    @State var dragSelection: Range<Int>?
-//    @State var line: Line?
-//    var onOpenFeedback: (Range<Int>) -> Void
-//
-//    var body: some View {
-//        ZStack {
-//            CodeEditor(source: file.code ?? "loading...",
-//                       language: .swift,
-//                       theme: theme,
-//                       fontSize: $fontSize,
-//                       flags: editorFlags,
-//                       highlightedRanges: mockHighlights,
-//                       dragSelection: $dragSelection,
-//                       line: $line,
-//                       showAddFeedback: $cvm.showAddFeedback)
-//        }
-//    }
-//
-//    var mockHighlights: [HighlightedRange] {
-//        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow),
-//                HighlightedRange(range: NSRange(location: 30, length: 10), color: UIColor.red)]
-//    }
-//
-//    var editorFlags: CodeEditor.Flags {
-//        if colorScheme == .dark {
-//            return .blackBackground
-//        } else {
-//            return .selectable
-//        }
-//    }
-//
-//    var theme: CodeEditor.ThemeName {
-//        if colorScheme == .dark {
-//            return .ocean
-//        } else {
-//            return .xcode
-//        }
-//    }
-// }
+ struct CodeViewSelect: View {
+    @Environment(\.colorScheme) var colorScheme
+    @ObservedObject var cvm: CodeEditorViewModel
+    @ObservedObject var file: Node
+    @Binding var fontSize: CGFloat
+    @State var dragSelection: Range<Int>?
+    @State var line: Line?
+    var onOpenFeedback: (Range<Int>) -> Void
+
+    var body: some View {
+        ZStack {
+            CodeEditor(source: file.code ?? "loading...",
+                       language: .swift,
+                       theme: theme,
+                       fontSize: $fontSize,
+                       flags: editorFlags,
+                       highlightedRanges: mockHighlights,
+                       dragSelection: $dragSelection,
+                       line: $line,
+                       showAddFeedback: $cvm.showAddFeedback,
+                       selectedSection: $cvm.selectedSection)
+        }
+    }
+
+    var mockHighlights: [HighlightedRange] {
+        return [HighlightedRange(range: NSRange(location: 10, length: 10), color: UIColor.yellow),
+                HighlightedRange(range: NSRange(location: 30, length: 10), color: UIColor.red)]
+    }
+
+    var editorFlags: CodeEditor.Flags {
+        if colorScheme == .dark {
+            return .blackBackground
+        } else {
+            return .selectable
+        }
+    }
+
+    var theme: CodeEditor.ThemeName {
+        if colorScheme == .dark {
+            return .ocean
+        } else {
+            return .xcode
+        }
+    }
+ }


### PR DESCRIPTION
- Highlighting now works the same way it did with Runestone

The rounded corners that we had with Runestone aren't that easy to do, since NSAtrributedString background takes no argument. We should find a solution for that in a future PR since the current highlighting looks very plain.
(CodeViewSelect is for testing purposes only, will comment it out when merging)