### PR TITLE
ScrollToFeedback when tapping InlineFeedbackItem

### DIFF
--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -18,6 +18,7 @@ class CodeEditorViewModel: ObservableObject {
     @Published var selectedSection: NSRange?
     @Published var inlineHighlights: [String: [HighlightedRange]] = [:]
     @Published var showAddFeedback: Bool = false
+    @Published var scrollToRange: NSRange?
 
     var selectedSectionParsed: (NSRange, NSRange?)? {
         if let selectedFile = selectedFile, let selectedSection = selectedSection, let lines = selectedFile.lines {

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -18,7 +18,7 @@ class CodeEditorViewModel: ObservableObject {
     @Published var selectedSection: NSRange?
     @Published var inlineHighlights: [String: [HighlightedRange]] = [:]
     @Published var showAddFeedback: Bool = false
-    @Published var scrollToRange: NSRange?
+    var scrollToRange = ReferenceTypeRange(value: nil)
 
     var selectedSectionParsed: (NSRange, NSRange?)? {
         if let selectedFile = selectedFile, let selectedSection = selectedSection, let lines = selectedFile.lines {
@@ -91,6 +91,16 @@ class CodeEditorViewModel: ObservableObject {
     func deleteInlineHighlight(feedback: AssessmentFeedback) {
         if let filePath = feedback.file?.path {
             inlineHighlights[filePath]?.removeAll { $0.id == feedback.id.uuidString }
+        }
+    }
+}
+
+extension CodeEditorViewModel {
+    class ReferenceTypeRange {
+        var value: NSRange?
+
+        init(value: NSRange? = nil) {
+            self.value = value
         }
     }
 }

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -21,6 +21,10 @@ struct CodeView: UIViewControllerRepresentable {
         uiViewController.fontSize = cvm.editorFontSize
         uiViewController.file = file
         uiViewController.textView.highlightedRanges = cvm.inlineHighlights[file.path] ?? []
+        if let scrollToRange = cvm.scrollToRange {
+            uiViewController.textView.scrollRangeToVisible(scrollToRange)
+            cvm.scrollToRange = nil
+        }
     }
 
     func makeCoordinator() -> Coordinator {

--- a/Themis/Views/Assessment/CorrectionSidebar/GeneralFeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/GeneralFeedbackCellView.swift
@@ -36,6 +36,14 @@ struct GeneralFeedbackCellView: View {
                 Section {
                     ForEach(assessment.feedback.inlineFeedback) { feedback in
                         FeedbackCellView(feedback: feedback)
+                            .onTapGesture {
+                                if let file = feedback.file, let pId = assessment.submission?.participation.id {
+                                    cvm.openFile(file: file, participationId: pId)
+                                    cvm.scrollToRange = cvm.inlineHighlights[file.path]?.first {
+                                        $0.id == feedback.id.uuidString
+                                    }?.range
+                                }
+                            }
                             .listRowSeparator(.hidden)
                     }
                     .onDelete(perform: delete(at:))

--- a/Themis/Views/Assessment/CorrectionSidebar/GeneralFeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/GeneralFeedbackCellView.swift
@@ -39,7 +39,7 @@ struct GeneralFeedbackCellView: View {
                             .onTapGesture {
                                 if let file = feedback.file, let pId = assessment.submission?.participation.id {
                                     cvm.openFile(file: file, participationId: pId)
-                                    cvm.scrollToRange = cvm.inlineHighlights[file.path]?.first {
+                                    cvm.scrollToRange.value = cvm.inlineHighlights[file.path]?.first {
                                         $0.id == feedback.id.uuidString
                                     }?.range
                                 }


### PR DESCRIPTION
- When tapping an item of the InlineFeedbacks Section in GeneralFeedbackCellView the related file is opened and it scrolls to the range of the feedback so it is visible on screen


https://user-images.githubusercontent.com/79016456/207150865-1efde590-2325-4b44-bfcf-29215f982a77.MOV

