### PR TITLE
Show test overview bar in problem statement

### DIFF
--- a/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
+++ b/Themis/ViewModels/CorrectionSidebar/ProblemStatementCellViewModel.swift
@@ -28,9 +28,16 @@ struct ProblemStatementMD: ProblemStatementPart {
     let text: String
 }
 
+struct BundledTest: Equatable {
+    var testCase: String
+    var passed: Bool
+}
+
 class ProblemStatementCellViewModel: ObservableObject {
 
     @Published var problemStatementParts: [any ProblemStatementPart] = []
+
+    @Published var bundledTests: [BundledTest] = []
 
     func convertProblemStatement(problemStatement: String, feedbacks: [AssessmentFeedback], colorScheme: ColorScheme) {
         var index = problemStatement.startIndex
@@ -76,9 +83,11 @@ class ProblemStatementCellViewModel: ObservableObject {
             if line.contains("[task][") && line.contains("0") {
                 line = calculateScoreOfPassingTests(line)
                 line = line.replacingOccurrences(of: "[task][", with: " ![Test failed](asset:///TestFailedSymbol) **")
+                bundledTests.append(BundledTest(testCase: line, passed: false))
             } else if line.contains("[task][") && line.contains("1") {
                 line = calculateScoreOfPassingTests(line)
                 line = line.replacingOccurrences(of: "[task][", with: " ![Test passed](asset:///TestPassedSymbol) **")
+                bundledTests.append(BundledTest(testCase: line, passed: true))
             }
 
             problemStatementText.append(line + "\n")

--- a/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
@@ -20,9 +20,35 @@ struct ProblemStatementCellView: View {
             Text("Problem Statement")
                 .font(.largeTitle)
 
+            ZStack {
+                Divider()
+                    .frame(height: 5)
+                    .overlay(.gray)
+                HStack {
+                    ForEach(vm.bundledTests, id: \.testCase) { bundledTest in
+                        if bundledTest != vm.bundledTests.first {
+                            Spacer()
+                        }
+                        if bundledTest.passed {
+                            Image("TestPassedSymbol")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: 30, maxHeight: 30)
+                                .background(colorScheme == .light ? .white : .black)
+                        } else {
+                            Image("TestFailedSymbol")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: 30, maxHeight: 30)
+                                .background(colorScheme == .light ? .white : .black)
+                        }
+                    }
+                }
+            }
+
             ForEach(vm.problemStatementParts, id: \.text) { part in
-                if let puml = part as? ProblemStatementPlantUML {
-                    AsyncImage(url: puml.url) { image in
+                if let uml = part as? ProblemStatementPlantUML {
+                    AsyncImage(url: uml.url) { image in
                         image.resizable()
                             .aspectRatio(contentMode: .fit)
                     } placeholder: {

--- a/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
@@ -34,13 +34,13 @@ struct ProblemStatementCellView: View {
                                 .resizable()
                                 .scaledToFit()
                                 .frame(maxWidth: 30, maxHeight: 30)
-                                .background(colorScheme == .light ? .white : .black)
+                                .background(Color(.systemBackground))
                         } else {
                             Image("TestFailedSymbol")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(maxWidth: 30, maxHeight: 30)
-                                .background(colorScheme == .light ? .white : .black)
+                                .background(Color(.systemBackground))
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds the test overview bar known from Artemis into the problem statement.

<img width="817" alt="Bildschirm­foto 2022-12-12 um 22 05 15" src="https://user-images.githubusercontent.com/116847304/207154368-fb803027-337a-4ac9-84d7-e6cb791d74b6.png">

<img width="817" alt="Bildschirm­foto 2022-12-12 um 22 05 39" src="https://user-images.githubusercontent.com/116847304/207154393-c78817bf-35c4-4b38-a090-d7f732d490fe.png">
