### PR TITLE
Make search fuzzy

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */; };
 		DA249E9A293029A3008DE1D5 /* AuthenticatedPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */; };
 		DA295CC6293A67EB000E04DC /* AuthenticationEnvironmentVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA295CC5293A67EB000E04DC /* AuthenticationEnvironmentVariables.swift */; };
+		DA94AD3E294791500027B303 /* SubmissionSearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA94AD3D294791500027B303 /* SubmissionSearchResult.swift */; };
 		E119ED992922D89900626DEA /* Submission.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED982922D89900626DEA /* Submission.swift */; };
 		E119ED9B2922DE4700626DEA /* Assessment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9A2922DE4700626DEA /* Assessment.swift */; };
 		E119ED9F2922F48A00626DEA /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E119ED9E2922F48A00626DEA /* Repository.swift */; };
@@ -117,6 +118,7 @@
 		DA249E9729302531008DE1D5 /* PreviewAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewAuthenticationViewModel.swift; sourceTree = "<group>"; };
 		DA249E99293029A3008DE1D5 /* AuthenticatedPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedPreview.swift; sourceTree = "<group>"; };
 		DA295CC5293A67EB000E04DC /* AuthenticationEnvironmentVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationEnvironmentVariables.swift; sourceTree = "<group>"; };
+		DA94AD3D294791500027B303 /* SubmissionSearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionSearchResult.swift; sourceTree = "<group>"; };
 		E119ED982922D89900626DEA /* Submission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Submission.swift; path = Themis/Models/Submission.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9A2922DE4700626DEA /* Assessment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Assessment.swift; path = Themis/Models/Assessment.swift; sourceTree = SOURCE_ROOT; };
 		E119ED9E2922F48A00626DEA /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Repository.swift; path = Themis/Models/Repository.swift; sourceTree = SOURCE_ROOT; };
@@ -381,6 +383,7 @@
 			children = (
 				DA249E9529301E72008DE1D5 /* SubmissionListViewModel.swift */,
 				E1DC9BA4293D28E900674F5B /* SubmissionSearchViewModel.swift */,
+				DA94AD3D294791500027B303 /* SubmissionSearchResult.swift */,
 			);
 			path = SubmissionList;
 			sourceTree = "<group>";
@@ -696,6 +699,7 @@
 				E58C68062935037C008E6FEE /* EditFeedbackView.swift in Sources */,
 				E2192ED7291E57810092CE58 /* RESTError.swift in Sources */,
 				E2192EDE291E687C0092CE58 /* Authentication.swift in Sources */,
+				DA94AD3E294791500027B303 /* SubmissionSearchResult.swift in Sources */,
 				E2192EE3291E74620092CE58 /* AuthenticationViewModel.swift in Sources */,
 				83396D2E29155935003EF727 /* ThemisApp.swift in Sources */,
 				E21AF058292B9D4C0096ACFC /* HighlightName.swift in Sources */,

--- a/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
@@ -7,40 +7,36 @@
 
 import Foundation
 
-// https://stackoverflow.com/a/44102415/4306257
-private func levDis(_ w1: String, _ w2: String) -> Int {
-    let empty = [Int](repeating: 0, count: w2.count)
-    var last = [Int](0...w2.count)
-
-    for (index, char1) in w1.enumerated() {
-        var cur = [index + 1] + empty
-        for (index2, char2) in w2.enumerated() {
-            cur[index2 + 1] = char1 == char2 ? last[index2] : min(last[index2], last[index2 + 1], cur[index2]) + 1
-        }
-        last = cur
-    }
-    return last.last!
-}
-
-private func levDisCaseInsensitiveTrimmed(_ w1: String, _ w2: String) -> Int {
-    return levDis(
-        w1.lowercased().trimmingCharacters(in: .whitespaces),
-        w2.lowercased().trimmingCharacters(in: .whitespaces)
-    )
-}
-
-private func scoreCalculation(reference: String, forText: String) -> Double {
-    // score is case insentitive Levensthein distance relative to forText length
-    // and also the reference length so that they are relatively stable
-    return Double(levDisCaseInsensitiveTrimmed(reference, forText)) / Double(forText.count) / Double(reference.count)
-}
-
 struct SubmissionSearchResult {
     let forText: String
     let submission: Submission
 
-    private func prepareStringCompare(_ str: String) -> String {
-        return str.lowercased().trimmingCharacters(in: .whitespaces)
+    // https://stackoverflow.com/a/44102415/4306257
+    private static func levDis(_ w1: String, _ w2: String) -> Int {
+        let empty = [Int](repeating: 0, count: w2.count)
+        var last = [Int](0...w2.count)
+
+        for (index, char1) in w1.enumerated() {
+            var cur = [index + 1] + empty
+            for (index2, char2) in w2.enumerated() {
+                cur[index2 + 1] = char1 == char2 ? last[index2] : min(last[index2], last[index2 + 1], cur[index2]) + 1
+            }
+            last = cur
+        }
+        return last.last!
+    }
+
+    private static func levDisCaseInsensitiveTrimmed(_ w1: String, _ w2: String) -> Int {
+        return levDis(
+            w1.lowercased().trimmingCharacters(in: .whitespaces),
+            w2.lowercased().trimmingCharacters(in: .whitespaces)
+        )
+    }
+
+    private static func scoreCalculation(reference: String, forText: String) -> Double {
+        // score is case insentitive Levensthein distance relative to forText length
+        // and also the reference length so that they are relatively stable
+        return Double(levDisCaseInsensitiveTrimmed(reference, forText)) / Double(forText.count) / Double(reference.count)
     }
 
     private var student: Student {
@@ -51,23 +47,23 @@ struct SubmissionSearchResult {
 
     private var nameScore: Double {
         get {
-            scoreCalculation(reference: forText, forText: student.name)
+            Self.scoreCalculation(reference: forText, forText: student.name)
         }
     }
     private var firstNameScore: Double {
         get {
-            scoreCalculation(reference: forText, forText: student.firstName)
+            Self.scoreCalculation(reference: forText, forText: student.firstName)
         }
     }
     private var lastNameScore: Double {
         get {
             guard let lastName = student.lastName else { return Double(Int.max) }
-            return scoreCalculation(reference: forText, forText: lastName)
+            return Self.scoreCalculation(reference: forText, forText: lastName)
         }
     }
     private var loginScore: Double {
         get {
-            scoreCalculation(reference: forText, forText: student.login)
+            Self.scoreCalculation(reference: forText, forText: student.login)
         }
     }
 

--- a/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
@@ -39,8 +39,8 @@ struct SubmissionSearchResult {
     let forText: String
     let submission: Submission
 
-    private func prepareStringCompare(_ s: String) -> String {
-        return s.lowercased().trimmingCharacters(in: .whitespaces)
+    private func prepareStringCompare(_ str: String) -> String {
+        return str.lowercased().trimmingCharacters(in: .whitespaces)
     }
 
     private var student: Student {

--- a/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
@@ -12,10 +12,10 @@ private func levDis(_ w1: String, _ w2: String) -> Int {
     let empty = [Int](repeating: 0, count: w2.count)
     var last = [Int](0...w2.count)
 
-    for (i, char1) in w1.enumerated() {
-        var cur = [i + 1] + empty
-        for (j, char2) in w2.enumerated() {
-            cur[j + 1] = char1 == char2 ? last[j] : min(last[j], last[j + 1], cur[j]) + 1
+    for (index, char1) in w1.enumerated() {
+        var cur = [index + 1] + empty
+        for (index2, char2) in w2.enumerated() {
+            cur[index2 + 1] = char1 == char2 ? last[index2] : min(last[index2], last[index2 + 1], cur[index2]) + 1
         }
         last = cur
     }

--- a/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionSearchResult.swift
@@ -1,0 +1,80 @@
+//
+//  SubmissionSearchResult.swift
+//  Themis
+//
+//  Created by Paul Schwind on 12.12.22.
+//
+
+import Foundation
+
+// https://stackoverflow.com/a/44102415/4306257
+private func levDis(_ w1: String, _ w2: String) -> Int {
+    let empty = [Int](repeating: 0, count: w2.count)
+    var last = [Int](0...w2.count)
+
+    for (i, char1) in w1.enumerated() {
+        var cur = [i + 1] + empty
+        for (j, char2) in w2.enumerated() {
+            cur[j + 1] = char1 == char2 ? last[j] : min(last[j], last[j + 1], cur[j]) + 1
+        }
+        last = cur
+    }
+    return last.last!
+}
+
+private func levDisCaseInsensitiveTrimmed(_ w1: String, _ w2: String) -> Int {
+    return levDis(
+        w1.lowercased().trimmingCharacters(in: .whitespaces),
+        w2.lowercased().trimmingCharacters(in: .whitespaces)
+    )
+}
+
+private func scoreCalculation(reference: String, forText: String) -> Double {
+    // score is case insentitive Levensthein distance relative to forText length
+    // and also the reference length so that they are relatively stable
+    return Double(levDisCaseInsensitiveTrimmed(reference, forText)) / Double(forText.count) / Double(reference.count)
+}
+
+struct SubmissionSearchResult {
+    let forText: String
+    let submission: Submission
+
+    private func prepareStringCompare(_ s: String) -> String {
+        return s.lowercased().trimmingCharacters(in: .whitespaces)
+    }
+
+    private var student: Student {
+        get {
+            submission.participation.student
+        }
+    }
+
+    private var nameScore: Double {
+        get {
+            scoreCalculation(reference: forText, forText: student.name)
+        }
+    }
+    private var firstNameScore: Double {
+        get {
+            scoreCalculation(reference: forText, forText: student.firstName)
+        }
+    }
+    private var lastNameScore: Double {
+        get {
+            guard let lastName = student.lastName else { return Double(Int.max) }
+            return scoreCalculation(reference: forText, forText: lastName)
+        }
+    }
+    private var loginScore: Double {
+        get {
+            scoreCalculation(reference: forText, forText: student.login)
+        }
+    }
+
+    // search result with lower score is better
+    var score: Double {
+        get {
+            min(nameScore, firstNameScore, lastNameScore, loginScore)
+        }
+    }
+}


### PR DESCRIPTION
This PR enables fuzzy search for the submissions. It works by calculating the Levelshtein distance between search and each of
- name
- firstName
- lastName
- login identifier
...and taking the minimum score out of those, normalized by using the text lengths. 

Every search result that has a score of max 1.15*bestScore is shown (I just chose what felt nice when trying it out).


https://user-images.githubusercontent.com/9006596/207163767-c5b63c15-00f3-4579-9ecb-6c12e0eedb7f.mp4

