### PR TITLE
Folders are now clickable

### DIFF
--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -3,36 +3,41 @@ import SwiftUI
 struct FiletreeSidebarView: View {
     @EnvironmentObject var assessmentViewModel: AssessmentViewModel
     @EnvironmentObject var cvm: CodeEditorViewModel
-
+    
     var body: some View {
         VStack(alignment: .leading) {
             Text("Filetree")
                 .font(.title)
                 .bold()
                 .padding(.leading, 18)
-            if let fileTree = cvm.fileTree {
-                List {
-                    OutlineGroup(fileTree, id: \.path, children: \.children) { tree in
-                        Text(tree.name)
-                            .bold(tree == cvm.selectedFile)
+            List {
+                OutlineGroup(cvm.fileTree, id: \.path, children: \.children) { tree in
+                    Group {
+                        if tree.type == .folder {
+                            Text(tree.name)
+                        } else {
+                            Button {
+                                withAnimation {
+                                    guard let pId = assessmentViewModel.submission?.participation.id else { return }
+                                    cvm.openFile(file: tree, participationId: pId)
+                                }
+                            } label: {
+                                Text(tree.name)
+                            }
+                            .buttonStyle(PlainButtonStyle())
                             .padding(.horizontal)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                            .bold(tree === cvm.selectedFile)
                             .background(tree === cvm.selectedFile ? Color(UIColor.systemGray5) : Color(UIColor.systemBackground))
                             .cornerRadius(10)
-                            .tag(tree)
-                            .onTapGesture {
-                                if tree.type == .file {
-                                    withAnimation {
-                                        guard let pId = assessmentViewModel.submission?.participation.id else { return }
-                                        cvm.openFile(file: tree, participationId: pId)
-                                    }
-                                }
-                            }
+                        }
                     }
-                    .listRowSeparator(.hidden)
                 }
-                .listStyle(.inset)
+                .listRowSeparator(.hidden)
             }
+            .listStyle(.inset)
         }
     }
+    
+    
 }

--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -12,25 +12,23 @@ struct FiletreeSidebarView: View {
                 .padding(.leading, 18)
             List {
                 OutlineGroup(cvm.fileTree, id: \.path, children: \.children) { tree in
-                    Group {
-                        if tree.type == .folder {
-                            Text(tree.name)
-                        } else {
-                            Button {
-                                withAnimation {
-                                    guard let pId = assessmentViewModel.submission?.participation.id else { return }
-                                    cvm.openFile(file: tree, participationId: pId)
-                                }
-                            } label: {
-                                Text(tree.name)
+                    if tree.type == .folder {
+                        Text(tree.name)
+                    } else {
+                        Button {
+                            withAnimation {
+                                guard let pId = assessmentViewModel.submission?.participation.id else { return }
+                                cvm.openFile(file: tree, participationId: pId)
                             }
-                            .buttonStyle(PlainButtonStyle())
-                            .padding(.horizontal)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-                            .bold(tree === cvm.selectedFile)
-                            .background(tree === cvm.selectedFile ? Color(UIColor.systemGray5) : Color(UIColor.systemBackground))
-                            .cornerRadius(10)
+                        } label: {
+                            Text(tree.name)
                         }
+                        .buttonStyle(PlainButtonStyle())
+                        .padding(.horizontal)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                        .bold(tree === cvm.selectedFile)
+                        .background(tree === cvm.selectedFile ? Color(UIColor.systemGray5) : Color(UIColor.systemBackground))
+                        .cornerRadius(10)
                     }
                 }
                 .listRowSeparator(.hidden)


### PR DESCRIPTION
I implemented a feature so that you no longer need to click on the tiny arrow but instead you can click on the hole Folder label in order to expand or collapse it.

https://user-images.githubusercontent.com/16856573/207431446-8b8a8fe2-0b4a-44f1-9981-8bdcac8a84f3.mov

