### PR TITLE
round to one decimal and change default font size to 22

### DIFF
--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -13,7 +13,7 @@ class CodeEditorViewModel: ObservableObject {
     @Published var fileTree: [Node] = []
     @Published var openFiles: [Node] = []
     @Published var selectedFile: Node?
-    @Published var editorFontSize = CGFloat(14) // Default font size
+    @Published var editorFontSize = CGFloat(22) // Default font size
     @Published var currentlySelecting: Bool = false
     @Published var selectedSection: NSRange?
     @Published var inlineHighlights: [String: [HighlightedRange]] = [:]

--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -323,8 +323,10 @@ struct AssessmentView: View {
                         .foregroundColor(.red)
                 } else {
                     Text("""
-                         \(vm.feedback.score.formatted(FloatingPointFormatStyle()))/\
-                         \(submission.participation.exercise.maxPoints.formatted(FloatingPointFormatStyle()))
+                         \(Double(round(10 * vm.feedback.score) / 10)
+                         .formatted(FloatingPointFormatStyle()))/\
+                         \(submission.participation.exercise.maxPoints
+                         .formatted(FloatingPointFormatStyle()))
                          """)
                         .foregroundColor(.white)
                 }

--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct FiletreeSidebarView: View {
     @EnvironmentObject var assessmentViewModel: AssessmentViewModel
     @EnvironmentObject var cvm: CodeEditorViewModel
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("Filetree")
@@ -36,6 +36,5 @@ struct FiletreeSidebarView: View {
             .listStyle(.inset)
         }
     }
-    
-    
+
 }


### PR DESCRIPTION
- Round decimals of score to one decimal to avoid this:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/64660684/207612036-adfebc44-8c82-4709-a7ed-cee69b02a5b9.png">

- change default font size to 22 for design review