### PR TITLE
Rework code editor padding & Fix listRowBackground in dark mode

### DIFF
--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -30,7 +30,7 @@ struct AssessmentView: View {
                         cvm: cvm,
                         templateParticipationId: vm.submission?.participation.exercise.templateParticipation.id ?? -1
                     )
-                        .padding(.top, 50)
+                        .padding(.top, 35)
                         .frame(width: dragWidthLeft)
                     leftGrip
                         .edgesIgnoringSafeArea(.bottom)
@@ -52,8 +52,8 @@ struct AssessmentView: View {
                 Image(systemName: "sidebar.left")
                     .font(.system(size: 23))
             }
-            .padding(.top)
-            .padding(.leading, 18)
+            .padding(.top, 4)
+            .padding(.leading, 13)
         }
         .overlay {
             if umlVM.showUMLFullScreen {

--- a/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeEditorView.swift
@@ -17,7 +17,7 @@ struct CodeEditorView: View {
                 VStack {
                     HStack {
                         Spacer()
-                            .frame(width: showFileTree ? 0 : 40)
+                            .frame(width: showFileTree ? 0 : 55)
                         TabsView(cvm: cvm)
                     }
                     CodeView(
@@ -32,6 +32,5 @@ struct CodeEditorView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .padding(EdgeInsets(top: 0, leading: 10, bottom: 10, trailing: 10))
     }
 }

--- a/Themis/Views/Assessment/CodeEditor/TabsView.swift
+++ b/Themis/Views/Assessment/CodeEditor/TabsView.swift
@@ -47,7 +47,6 @@ struct TabsView: View {
                 .onChange(of: cvm.selectedFile, perform: { file in
                     scrollReader.scrollTo(file, anchor: nil)
                 })
-                .padding()
             }
         }
     }

--- a/Themis/Views/Assessment/CorrectionSidebar/FeedbackListView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/FeedbackListView.swift
@@ -35,6 +35,7 @@ struct FeedbackListView: View {
                             feedback: feedback
                         )
                             .listRowSeparator(.hidden)
+                            .listRowBackground(Color(UIColor.systemBackground))
                     }
                     .onDelete(perform: delete(at:))
                 }.headerProminence(.increased)
@@ -48,6 +49,7 @@ struct FeedbackListView: View {
                             feedback: feedback
                         )
                             .listRowSeparator(.hidden)
+                            .listRowBackground(Color(UIColor.systemBackground))
                     }
                     .onDelete(perform: delete(at:))
                 } header: {
@@ -64,6 +66,7 @@ struct FeedbackListView: View {
                             cvm: cvm,
                             feedback: feedback)
                             .listRowSeparator(.hidden)
+                            .listRowBackground(Color(UIColor.systemBackground))
                     }
                 } header: {
                     HStack {


### PR DESCRIPTION
- removed the padding around code editor view (had to do some adjustments with the position of the ZStack sidemenu button to make it aligned with the tabs. We could maybe think about putting the sidebar button in the toolbar to make it look even better, but I think the current solution is also fine)
- the gray background of feedback cells in the list is not shown in dark mode anymore

https://user-images.githubusercontent.com/79016456/211862085-7c4a6320-f873-4f32-b6b7-347a612aa11f.mov

