### PR TITLE
Improve problem statement code reference

### DIFF
--- a/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/ProblemStatementCellView.swift
@@ -64,6 +64,10 @@ struct ProblemStatementCellView: View {
                     })
                 } else {
                     Markdown(part.text)
+                        .markdownTextStyle(\.code) {
+                            FontFamilyVariant(.monospaced)
+                            ForegroundColor(.red)
+                        }
                         .markdownImageProvider(.asset)
                 }
             }


### PR DESCRIPTION
With the new swift-markdown-ui version it is now possible to make the class names and function names in red, as it is in Artemis.
![image](https://user-images.githubusercontent.com/116847304/213935418-070c7469-1305-42d4-859b-62fa2ed9e925.png)
