### PR TITLE
Code Editor Performance

### DIFF
--- a/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -181,10 +181,6 @@ public struct UXCodeTextViewRepresentable: UXViewRepresentable {
             parent.editorBindings.flags.contains(.selectable)
             || parent.editorBindings.flags.contains(.editable)
         }
-        
-        public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-            scrollView.setNeedsDisplay()
-        }
     }
 
     public func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
The CodeEditor does not need to redraw every time someone scrolled.
This was needed in the past with the old selecting and drawing approach.
Removing it reduces CPU usage from 100% to 20% on my iPad.
It should not change any behavior in the app