### PR TITLE
Assign exercise to current exercises if no release date

### DIFF
--- a/Themis/Models/Exercise.swift
+++ b/Themis/Models/Exercise.swift
@@ -39,33 +39,28 @@ struct Exercise: Codable {
     }
     
     func isFormer() -> Bool {
-        guard let assessmentDueDate else {
-            return false
+        if let assessmentDueDate {
+            return assessmentDueDate < dateNow()
         }
-        return assessmentDueDate < dateNow()
+        return false
     }
     
     func isCurrent() -> Bool {
-        // exercises without release date are future exercises
-        guard let releaseDate else {
-            return false
+        if let releaseDate {
+            return releaseDate <= dateNow()
         }
-        if releaseDate >= dateNow() {
-            return false
+        if let assessmentDueDate {
+            return dateNow() <= assessmentDueDate
         }
-        // exercises without assessment due date are current exercises
-        guard let assessmentDueDate else {
-            return true
-        }
-        return dateNow() < assessmentDueDate
+        return true
     }
     
     func isFuture() -> Bool {
-        // exercises without a release date are future exercises
-        guard let releaseDate else {
-            return true
+        // exercises without a release date are automatically published
+        if let releaseDate {
+            return dateNow() < releaseDate
         }
-        return dateNow() < releaseDate
+        return false
     }
 }
 

--- a/Themis/Views/Exercises/ExercisesListView.swift
+++ b/Themis/Views/Exercises/ExercisesListView.swift
@@ -25,6 +25,7 @@ struct ExercisesListView: View {
                 exerciseSection(
                     title: "Former Exercises",
                     dateProperties: [
+                        releaseDate,
                         dueDate,
                         assessmentDueDate
                     ],
@@ -34,6 +35,7 @@ struct ExercisesListView: View {
                 exerciseSection(
                     title: "Current Exercises",
                     dateProperties: [
+                        releaseDate,
                         dueDate,
                         assessmentDueDate
                     ],
@@ -43,7 +45,9 @@ struct ExercisesListView: View {
                 exerciseSection(
                     title: "Future Exercises",
                     dateProperties: [
-                        releaseDate
+                        releaseDate,
+                        dueDate,
+                        assessmentDueDate
                     ],
                     predicate: { $0.isFuture() }
                 )


### PR DESCRIPTION
From now on, exercises without a release date are automatically in the current exercises section, as they are automatically published to students as well!
I've added all three dates to each section to show that and because @katjanakosic needs them anyway for her timeline task.

![image](https://user-images.githubusercontent.com/116847304/214641835-0bcc2a85-2a0e-4cb0-89b5-7efb0845ec7a.png)
