### PR TITLE
Show highlights after save

### DIFF
--- a/Themis/Models/Assessment.swift
+++ b/Themis/Models/Assessment.swift
@@ -104,6 +104,13 @@ class AssessmentResult: Encodable, ObservableObject {
         computedFeedbacks[index].credits = credits
     }
     
+    func assignFile(id: UUID, file: Node) {
+        guard let index = (feedbacks.firstIndex { $0.id == id }) else {
+            return
+        }
+        computedFeedbacks[index].file = file
+    }
+    
     func undo() {
         undoManager.undo()
     }
@@ -208,6 +215,7 @@ extension AssessmentFeedback: Decodable {
     enum DecodingKeys: String, CodingKey {
         case text
         case detailText
+        case reference
         case credits
         case assessmentType = "type"
         case positive
@@ -217,6 +225,7 @@ extension AssessmentFeedback: Decodable {
         let values = try decoder.container(keyedBy: DecodingKeys.self)
         text = try? values.decode(String?.self, forKey: .text)
         detailText = try? values.decode(String?.self, forKey: .detailText)
+        reference = try? values.decode(String?.self, forKey: .reference)
         credits = try values.decode(Double?.self, forKey: .credits) ?? 0.0
         assessmentType = try values.decode(AssessmentType.self, forKey: .assessmentType)
         // assessment type `MANUAL_UNREFERENCED` does not have positive

--- a/Themis/Models/Repository.swift
+++ b/Themis/Models/Repository.swift
@@ -38,6 +38,20 @@ class Node: Hashable, ObservableObject {
     @Published var diffLines: [Int] = []
     @Published var isNewFile = false
     private var diffCalculated = false
+    var recursiveChildren: [Node]? {
+        var allChildren: [Node] = []
+        if var nodesToCheck = children {
+            while !nodesToCheck.isEmpty {
+                let currentNode = nodesToCheck.removeFirst()
+                    allChildren.append(currentNode)
+                if let children = currentNode.children {
+                    nodesToCheck.append(contentsOf: children)
+                }
+            }
+            return allChildren
+        }
+        return nil
+    }
     /// property that calculates a lines character range to get line number of selectedTextRange
     var lines: [NSRange]? {
         if let code = code {

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -52,13 +52,11 @@ class CodeEditorViewModel: ObservableObject {
     private var allFiles: [Node] {
         var files: [Node] = []
         var nodesToCheck = fileTree
+        nodesToCheck.forEach { nodesToCheck.append(contentsOf: $0.recursiveChildren ?? []) }
         while !nodesToCheck.isEmpty {
             let currentNode = nodesToCheck.removeFirst()
             if currentNode.type == .file {
                 files.append(currentNode)
-            }
-            if let children = currentNode.children {
-                nodesToCheck.append(contentsOf: children)
             }
         }
         return files

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -103,9 +103,7 @@ class CodeEditorViewModel: ObservableObject {
     
     @MainActor
     func loadInlineHighlight(assessmentResult: AssessmentResult, participationId: Int) async {
-        for i in 0..<assessmentResult.inlineFeedback.count {
-            // extract file path
-            let feedback = assessmentResult.inlineFeedback[i]
+        for feedback in assessmentResult.inlineFeedback {
             // the reference is extracted from the text since it is more detailed (includes columns and multilines)
             if let text = feedback.text {
                 let components = text.components(separatedBy: .whitespaces)

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -128,6 +128,7 @@ class CodeEditorViewModel: ObservableObject {
                 }
             }
         }
+        undoManager.removeAllActions()
     }
     
     func deleteInlineHighlight(feedback: AssessmentFeedback) {

--- a/Themis/Views/Assessment/AssessmentSubmissionLoaderView.swift
+++ b/Themis/Views/Assessment/AssessmentSubmissionLoaderView.swift
@@ -29,6 +29,7 @@ struct AssessmentSubmissionLoaderView: View {
             await avm.getSubmission(id: submissionID)
             if let pId = avm.submission?.participation.id {
                 await cvm.initFileTree(participationId: pId)
+                await cvm.loadInlineHighlight(assessmentResult: avm.assessmentResult, participationId: pId)
             }
         }
     }


### PR DESCRIPTION
- highlights are now shown after reopening a previously saved file

(This required extracting the file and column reference from the decoded feedbacks and recalculating the related range for the highlight, which is why the code became rather complex. I already divided it into sub functions and added comments to make everything clear, but let me know if something is still unclear)

https://user-images.githubusercontent.com/79016456/214981820-d8d6c9fe-39cf-42c4-b2a4-3c45dc282667.mov

