### PR TITLE
implement Feedback mode

### DIFF
--- a/CodeEditor/Sources/CodeEditor/CodeEditor.swift
+++ b/CodeEditor/Sources/CodeEditor/CodeEditor.swift
@@ -175,6 +175,7 @@ public struct CodeEditor {
         /// whitespace as on the previous line.
         public static let smartIndent = Flags(rawValue: 1 << 2)
         public static let blackBackground = Flags(rawValue: 1 << 3)
+        public static let feedbackMode = Flags(rawValue: 1 << 4)
 
         public static let defaultViewerFlags: Flags = [ .selectable ]
         public static let defaultEditorFlags: Flags =

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
@@ -82,6 +82,8 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
         }
     }
     
+    var feedbackMode = true
+    
     var lightBulbs = [LightbulbButton]()
     
     init() {
@@ -476,6 +478,7 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard feedbackMode else { return }
         guard let touch = touches.first else { return }
         if pencilOnly && touch.type == .pencil || !pencilOnly {
             self.firstPoint = touch.location(in: self)
@@ -484,6 +487,7 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
     }
     
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard feedbackMode else { return }
         guard let touch = touches.first else { return }
         if pencilOnly && touch.type == .pencil || !pencilOnly {
             self.secondPoint = touch.location(in: self)
@@ -494,6 +498,7 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
     
     
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard feedbackMode else { return }
         let coordinator = delegate as? UXCodeTextViewDelegate
         coordinator?.setDragSelection(dragSelection)
     }

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -141,7 +141,7 @@ public struct UXCodeTextViewRepresentable: UXViewRepresentable {
         
         public func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
             var additionalActions: [UIMenuElement] = []
-            if range.length > 0 {
+            if range.length > 0 && self.parent.editorBindings.flags.contains(.feedbackMode) {
                 let feedbackAction = UIAction(title: "Feedback") { _ in
                     self.parent.editorBindings.showAddFeedback.wrappedValue.toggle()
                 }
@@ -217,8 +217,10 @@ public struct UXCodeTextViewRepresentable: UXViewRepresentable {
                 assertionFailure("no text storage?")
                 textView.string = editorBindings.source.wrappedValue
             }
-            textView.feedbackSuggestions = editorBindings.feedbackSuggestions
-            textView.updateLightBulbs()
+            if editorBindings.flags.contains(.feedbackMode) {
+                textView.feedbackSuggestions = editorBindings.feedbackSuggestions
+                textView.updateLightBulbs()
+            }
         }
         textView.pencilOnly = editorBindings.pencilOnly.wrappedValue
         textView.dragSelection = self.editorBindings.dragSelection?.wrappedValue

--- a/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/CodeEditorViewModel.swift
@@ -65,12 +65,14 @@ class CodeEditorViewModel: ObservableObject {
     }
     
     @MainActor
-    func openFile(file: Node, participationId: Int, templateParticipationId: Int) {
+    func openFile(file: Node, participationId: Int, templateParticipationId: Int?) {
         if !openFiles.contains(where: { $0.path == file.path }) {
             openFiles.append(file)
             Task {
                 await file.fetchCode(participationId: participationId)
-                await file.calculateDiff(templateParticipationId: templateParticipationId)
+                if let templateParticipationId {
+                    await file.calculateDiff(templateParticipationId: templateParticipationId)
+                }
             }
         }
         selectedFile = file

--- a/Themis/Views/Assessment/CodeEditor/CodeView.swift
+++ b/Themis/Views/Assessment/CodeEditor/CodeView.swift
@@ -57,11 +57,11 @@ struct CodeView: View {
     }
     
     var editorFlags: CodeEditor.Flags {
-        if colorScheme == .dark {
-            return [.selectable, .blackBackground]
-        } else {
-            return .selectable
-        }
+        var flags: CodeEditor.Flags = []
+        flags.insert(.selectable)
+        if colorScheme == .dark { flags.insert(.blackBackground) }
+        if !readOnly { flags.insert(.feedbackMode) }
+        return flags
     }
     
     var theme: CodeEditor.ThemeName {

--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -43,7 +43,7 @@ struct FiletreeSidebarView: View {
     func nodeFileView(file: Node) -> some View {
         Button {
             withAnimation {
-                guard let participationID, let templateParticipationId else { return }
+                guard let participationID else { return }
                 cvm.openFile(file: file,
                          participationId: participationID,
                          templateParticipationId: templateParticipationId


### PR DESCRIPTION
The Code Editor now has a Feedback Mode. In this mode, you can perform all actions as usual. However, if you are not in Feedback Mode, you will not be able to select code with the pencil or finger and you will not be able to click on the Feedback button if you have selected something in the Text Editor.

Furthermore, I have made the templateExerciseID optional as I was unable to view old submissions due to it always being nil. I have also discovered the reason for this bug of not being able to view files, but I will discuss this in another PR with @tcw0.