### PR TITLE
Fix exercise in two sections simultaneously

### DIFF
--- a/Themis/Models/Exercise.swift
+++ b/Themis/Models/Exercise.swift
@@ -39,26 +39,26 @@ struct Exercise: Codable {
     }
     
     func isFormer() -> Bool {
-        if let assessmentDueDate {
-            return assessmentDueDate < dateNow()
+        if let assessmentDueDate, assessmentDueDate < dateNow() {
+            return true
         }
         return false
     }
     
     func isCurrent() -> Bool {
-        if let releaseDate {
-            return releaseDate <= dateNow()
+        if let releaseDate, dateNow() < releaseDate {
+            return false
         }
-        if let assessmentDueDate {
-            return dateNow() <= assessmentDueDate
+        if let assessmentDueDate, assessmentDueDate < dateNow() {
+            return false
         }
         return true
     }
     
     func isFuture() -> Bool {
         // exercises without a release date are automatically published
-        if let releaseDate {
-            return dateNow() < releaseDate
+        if let releaseDate, dateNow() < releaseDate {
+            return true
         }
         return false
     }


### PR DESCRIPTION
So far, it was possible that an exercise was in current and former exercises at the same time because of a bug when checking if release < dateNow(). This is fixed now. Furthermore, I restructured it a bit.

![image](https://user-images.githubusercontent.com/116847304/216769305-706b0492-b60c-4b10-93a4-7e6f81360ba0.png)
