### PR TITLE
Minor documentation improvements

### DIFF
--- a/docs/admin/app/deployment.rst
+++ b/docs/admin/app/deployment.rst
@@ -11,7 +11,7 @@ All changes on the develop branch are automatically deployed to TestFlight.
 
   * **Build and Release Pipeline:**
     
-    This pipeline is automatically triggered by changes in the Themis repository. It checks for swiftlint errors. It uses 
+    This pipeline is automatically triggered by changes in the Themis repository. It checks for `SwiftLint`_ errors. It uses 
     fastlane to build the app. If the change is on the develop branch then it releases to TestFlight.
 
 ~~~~~~~~~~~~~~~~~~~
@@ -31,3 +31,5 @@ via a public TestFlight link.
 
     This group gets the newest release manually via adding a certain build to their group. Furthermore, it is possible to 
     release notes.
+
+.. _SwiftLint: https://github.com/realm/SwiftLint

--- a/docs/admin/app/deployment.rst
+++ b/docs/admin/app/deployment.rst
@@ -1,0 +1,33 @@
+Deployment and Configuration
+===========================================
+
+.. Describe the steps an system administrator needs to take to install your system on the infrastructure described in the section above. If necessary explain any parameters like domains, IP addresses, ports, etc. within your system that need to be configured. This does not include details about the configuration of your infrastructure, which should already be described in the previous section.
+
+~~~~~~~~~~~~~~~
+CI/CD Pipeline
+~~~~~~~~~~~~~~~
+
+All changes on the develop branch are automatically deployed to TestFlight.
+
+  * **Build and Release Pipeline:**
+    
+    This pipeline is automatically triggered by changes in the Themis repository. It checks for swiftlint errors. It uses 
+    fastlane to build the app. If the change is on the develop branch then it releases to TestFlight.
+
+~~~~~~~~~~~~~~~~~~~
+TestFlight Release
+~~~~~~~~~~~~~~~~~~~
+
+TestFlight supports multiple user groups. In our case it is divided into Developers, Customer + Management and Tutors.
+It offers two kinds of testers, namely internal (Developers and Customer + Management) and external testers (Tutors). The 
+main difference is that interal testers are registered via their Apple-ID and external testers download the app anonymously 
+via a public TestFlight link.
+
+  * **Developers:**
+
+    They are able to downloads all version of the app and can always install the newest version.
+
+  * **Customer + Management and Tutors:**
+
+    This group gets the newest release manually via adding a certain build to their group. Furthermore, it is possible to 
+    release notes.

--- a/docs/admin/app/deployment.rst
+++ b/docs/admin/app/deployment.rst
@@ -20,7 +20,7 @@ TestFlight Release
 
 TestFlight supports multiple user groups. In our case it is divided into Developers, Customer + Management and Tutors.
 It offers two kinds of testers, namely internal (Developers and Customer + Management) and external testers (Tutors). The 
-main difference is that interal testers are registered via their Apple-ID and external testers download the app anonymously 
+main difference is that internal testers are registered via their Apple-ID and external testers download the app anonymously 
 via a public TestFlight link.
 
   * **Developers:**

--- a/docs/admin/app/index.rst
+++ b/docs/admin/app/index.rst
@@ -2,7 +2,6 @@ Themis App
 ===========================================
 
 .. toctree::
-    :caption: Themis App
     :includehidden:
     
     infrastructure

--- a/docs/admin/app/index.rst
+++ b/docs/admin/app/index.rst
@@ -1,0 +1,10 @@
+Themis App
+===========================================
+
+.. toctree::
+    :caption: Themis App
+    :includehidden:
+    
+    deployment
+    infrastructure
+    third-party

--- a/docs/admin/app/index.rst
+++ b/docs/admin/app/index.rst
@@ -5,6 +5,6 @@ Themis App
     :caption: Themis App
     :includehidden:
     
-    deployment
     infrastructure
+    deployment
     third-party

--- a/docs/admin/app/infrastructure.rst
+++ b/docs/admin/app/infrastructure.rst
@@ -1,0 +1,15 @@
+Infrastructure Setup
+===========================================
+
+.. Describe the setup of the infrastructure in terms of hardware, software and protocols so it can be configured by a system administrator at the client site. This include virtual machines, software packages etc. You can reuse the deployment diagram from the section Hardware/Software Mapping. Describe the installation and startup order for each component. You can reuse the use cases from the section Boundary Conditions. For example: If you have used docker reuse the Docker installation instructions from the cross project space.
+
+The app can be installed on iPads via `TestFlight`_. Therefore, it requires TestFlight to be installed on the iPad and the user
+to be part of at least one group, either via Apple-ID or via public TestFlight link. The only formal requirement is iPadOS 16.
+
+Apart from that, the iPad app can also be tested via XCode and its integrated Simulator. To prevent entering the Artemis 
+credentials every time rebuilding the app while testing, just add them to your XCode environment variables. For that, click on
+the Themis icon on the top and choose "Edit Scheme...". Under "Environment Variables", add ARTEMIS_STAGING_SERVER, 
+ARTEMIS_STAGING_USER and ARTEMIS_STAGING_PASSWORD with their according values. To use the preview feature in XCode, wrap
+your preview component with an AuthenticatedPreview.
+
+For future maintenance, the existing CI/CD-Pipeline and the TestFlight account is needed.

--- a/docs/admin/app/infrastructure.rst
+++ b/docs/admin/app/infrastructure.rst
@@ -8,9 +8,9 @@ to be part of at least one group, either via Apple-ID or via public TestFlight l
 
 Apart from that, the iPad app can also be tested via XCode and its integrated Simulator. To prevent entering the Artemis 
 credentials every time rebuilding the app while testing, just add them to your XCode environment variables. For that, click on
-the Themis icon on the top and choose "Edit Scheme...". Under "Environment Variables", add ARTEMIS_STAGING_SERVER, 
-ARTEMIS_STAGING_USER and ARTEMIS_STAGING_PASSWORD with their according values. To use the preview feature in XCode, wrap
-your preview component with an AuthenticatedPreview.
+the Themis icon on the top and choose "Edit Scheme...". Under "Environment Variables", add ``ARTEMIS_STAGING_SERVER``, 
+``ARTEMIS_STAGING_USER`` and ``ARTEMIS_STAGING_PASSWORD`` with their according values. To use the preview feature in XCode, wrap
+your preview component with an ``AuthenticatedPreview``.
 
 For future maintenance, the existing CI/CD-Pipeline and the TestFlight account is needed.
 

--- a/docs/admin/app/infrastructure.rst
+++ b/docs/admin/app/infrastructure.rst
@@ -13,3 +13,5 @@ ARTEMIS_STAGING_USER and ARTEMIS_STAGING_PASSWORD with their according values. T
 your preview component with an AuthenticatedPreview.
 
 For future maintenance, the existing CI/CD-Pipeline and the TestFlight account is needed.
+
+.. _TestFlight: https://testflight.apple.com/join/NmyhJo2V

--- a/docs/admin/app/third-party.rst
+++ b/docs/admin/app/third-party.rst
@@ -12,7 +12,7 @@ KeychainAccess
 
 The KeychainAccess library is used to securely store and retrieve sensitive information, 
 such as authentication tokens. 
-KeychainAccess provides a simple and secure way to store data in the iOS keychain.
+KeychainAccess provides a simple and secure way to store data in the iOS Keychain.
 
 Library repository: https://github.com/kishikawakatsumi/KeychainAccess (master branch)
 

--- a/docs/admin/app/third-party.rst
+++ b/docs/admin/app/third-party.rst
@@ -8,7 +8,7 @@ The Themis app utilizes a number of open-source libraries to enhance its functio
 This provides an overview of the libraries used in the Themis app.
 
 KeychainAccess
-------------
+--------------
 
 The KeychainAccess library is used to securely store and retrieve sensitive information, 
 such as authentication tokens. 
@@ -18,7 +18,7 @@ Library repository: https://github.com/kishikawakatsumi/KeychainAccess (master b
 
 
 SwiftUI-Cached-AsyncImage
-------------
+-------------------------
 
 The SwiftUI-Cached-AsyncImage library provides an easy way to load and cache images asynchronously in SwiftUI. 
 This library is used in the Themis app to display UML-Diagrams in a fast and efficient manner.
@@ -26,7 +26,7 @@ This library is used in the Themis app to display UML-Diagrams in a fast and eff
 Library repository: https://github.com/lorenzofiamingo/swiftui-cached-async-image (2.0.0 - Next Major)
 
 CodeEditor
-------------
+----------
 
 The CodeEditor library is a customizable and extensible code editor component for SwiftUI. The 
 library is used in the Themis app to provide a code editor for the user to read Code.
@@ -35,7 +35,7 @@ It was modified locally in order to select and give feedback in the Code Editor
 Library repository: https://github.com/ZeeZide/CodeEditor.git (locally modified)
 
 SwiftUIReorderableForEach
-------------
+-------------------------
 
 The SwiftUIReorderableForEach library is used to create reorderable lists in SwiftUI. 
 This library is used in the Themis app to provide the user with the ability to reorder the Tabs for open Code-Files.
@@ -44,7 +44,7 @@ Library repository: https://github.com/globulus/swiftui-reorderable-foreach (mai
 
 
 Swift-Markdown-ui
-------------
+-----------------
 
 The Swift-Markdown-ui library is used to parse and display markdown content in a SwiftUI app. 
 This library is used in the Themis app to display markdown content from Artemis in a clean and formatted manner.

--- a/docs/admin/app/third-party.rst
+++ b/docs/admin/app/third-party.rst
@@ -1,11 +1,6 @@
 Third-party Components
 ===========================================
 
-*****
-Themis iPad App
-*****
-
-
 Introduction
 ------------
 
@@ -55,46 +50,3 @@ The Swift-Markdown-ui library is used to parse and display markdown content in a
 This library is used in the Themis app to display markdown content from Artemis in a clean and formatted manner.
 
 Library repository: https://github.com/gonzalezreal/swift-markdown-ui (2.0.0 - next major)
-
-
-*****
-ThemisML
-*****
-
-Server
-------------
-ThemisML uses `FastAPI`_ for the web server and `uvicorn`_ as the ASGI server.
-
-Library repository FastAPI: https://github.com/tiangolo/fastapi (0.88.0)
-Library repository uvicorn: https://github.com/encode/uvicorn (0.20.0)
-
-Database
-------------
-To connect to the PostgreSQL database, ThemisML uses `SQLAlchemy`_ as the client and `Psycopg2`_ as the database driver.
-
-Library repository SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy (1.4.46)
-Library repository Psycopg2: https://github.com/psycopg/psycopg2 (2.9.5)
-
-Feedback generation
-------------
-For extracting the methods, we use `ANTL4`_ for python.
-To compare code, we use `CodeBERTScore`_, which is a wrapper for CodeBERT. Because it is not available on PyPI, we directly link to the GitHub repository in our requirements.
-
-Library repository ANTL4: https://github.com/antlr/antlr4 (4.11.1)
-
-Helpers
-------------
-The helper script ``determine-similarity-cutoff`` uses the `dataset`_ library to simplify working with the database.
-
-Library repository dataset: https://github.com/pudo/dataset (1.6.0)
-
-You can find the full list of third-party requirements including the most up-to-date version numbers in use in the ``requirements.txt`` files in the respective folders of the ThemisML repository. The main one is found in `feedback-suggestion/requirements.txt <https://github.com/ls1intum/Themis-ML/blob/develop/feedback-suggestion/requirements.txt>`_.
-
-.. links
-.. _FastAPI: https://fastapi.tiangolo.com/
-.. _uvicorn: https://www.uvicorn.org/
-.. _SQLAlchemy: https://www.sqlalchemy.org/
-.. _Psycopg2: https://www.psycopg.org/
-.. _ANTL4: https://www.antlr.org/
-.. _CodeBERTScore: https://github.com/neulab/code-bert-score
-.. _dataset: https://dataset.readthedocs.io/en/latest/

--- a/docs/admin/app/third-party.rst
+++ b/docs/admin/app/third-party.rst
@@ -23,7 +23,7 @@ SwiftUI-Cached-AsyncImage
 The SwiftUI-Cached-AsyncImage library provides an easy way to load and cache images asynchronously in SwiftUI. 
 This library is used in the Themis app to display UML-Diagrams in a fast and efficient manner.
 
-Library repository: https://github.com/lorenzofiamingo/swiftui-cached-async-image (2.0.0 - Next Major)
+Library repository: https://github.com/lorenzofiamingo/swiftui-cached-async-image (2.1.1 - Next Major)
 
 CodeEditor
 ----------

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -1,0 +1,9 @@
+Administrator Manual
+===========================================
+
+.. toctree::
+    :caption: Administrator Manual
+    :includehidden:
+    
+    app/index
+    themisml/index

--- a/docs/admin/index.rst
+++ b/docs/admin/index.rst
@@ -1,9 +1,0 @@
-Administrator Manual
-===========================================
-
-.. toctree::
-    :caption: Administrator Manual
-    :includehidden:
-    
-    app/index
-    themisml/index

--- a/docs/admin/issues.rst
+++ b/docs/admin/issues.rst
@@ -5,7 +5,7 @@ The feedback suggestion server ThemisML currently only works with Java projects.
 This should be easy to fix by creating an ANTLR grammar for every additional language to support and configuring the codeBERT similarity comparison accordingly.
 
 Creating a New ANTLR4 Grammar for ThemisML
-----------
+------------------------------------------
 You can get grammars for a lot of programming languages in this repository: https://github.com/antlr/grammars-v4
 You will find a parser and a lexer, which you will need to convert to Python files for ThemisML to use.
 

--- a/docs/admin/themisml/deployment.rst
+++ b/docs/admin/themisml/deployment.rst
@@ -3,43 +3,6 @@ Deployment and Configuration
 
 .. Describe the steps an system administrator needs to take to install your system on the infrastructure described in the section above. If necessary explain any parameters like domains, IP addresses, ports, etc. within your system that need to be configured. This does not include details about the configuration of your infrastructure, which should already be described in the previous section.
 
------------
-Themis App
------------
-
-~~~~~~~~~~~~~~~
-CI/CD Pipeline
-~~~~~~~~~~~~~~~
-
-All changes on the develop branch are automatically deployed to TestFlight.
-
-  * **Build and Release Pipeline:**
-    
-    This pipeline is automatically triggered by changes in the Themis repository. It checks for swiftlint errors. It uses 
-    fastlane to build the app. If the change is on the develop branch then it releases to TestFlight.
-
-~~~~~~~~~~~~~~~~~~~
-TestFlight Release
-~~~~~~~~~~~~~~~~~~~
-
-TestFlight supports multiple user groups. In our case it is divided into Developers, Customer + Management and Tutors.
-It offers two kinds of testers, namely internal (Developers and Customer + Management) and external testers (Tutors). The 
-main difference is that interal testers are registered via their Apple-ID and external testers download the app anonymously 
-via a public TestFlight link.
-
-  * **Developers:**
-
-    They are able to downloads all version of the app and can always install the newest version.
-
-  * **Customer + Management and Tutors:**
-
-    This group gets the newest release manually via adding a certain build to their group. Furthermore, it is possible to 
-    release notes.
-
-----------------
-ThemisML Server
-----------------
-
 ~~~~~~~~~~~~~~~~
 CI/CD Pipelines
 ~~~~~~~~~~~~~~~~

--- a/docs/admin/themisml/deployment.rst
+++ b/docs/admin/themisml/deployment.rst
@@ -1,3 +1,4 @@
+.. _themisml-deployment:
 Deployment and Configuration
 ===========================================
 

--- a/docs/admin/themisml/index.rst
+++ b/docs/admin/themisml/index.rst
@@ -2,7 +2,6 @@ ThemisML
 ===========================================
 
 .. toctree::
-    :caption: ThemisML
     :includehidden:
     
     infrastructure

--- a/docs/admin/themisml/index.rst
+++ b/docs/admin/themisml/index.rst
@@ -5,6 +5,6 @@ ThemisML
     :caption: ThemisML
     :includehidden:
     
-    deployment
     infrastructure
+    deployment
     third-party

--- a/docs/admin/themisml/index.rst
+++ b/docs/admin/themisml/index.rst
@@ -1,0 +1,10 @@
+ThemisML
+===========================================
+
+.. toctree::
+    :caption: ThemisML
+    :includehidden:
+    
+    deployment
+    infrastructure
+    third-party

--- a/docs/admin/themisml/infrastructure.rst
+++ b/docs/admin/themisml/infrastructure.rst
@@ -3,27 +3,8 @@ Infrastructure Setup
 
 .. Describe the setup of the infrastructure in terms of hardware, software and protocols so it can be configured by a system administrator at the client site. This include virtual machines, software packages etc. You can reuse the deployment diagram from the section Hardware/Software Mapping. Describe the installation and startup order for each component. You can reuse the use cases from the section Boundary Conditions. For example: If you have used docker reuse the Docker installation instructions from the cross project space.
 
-*****
-Themis App
-*****
-
-The app can be installed on iPads via `TestFlight`_. Therefore, it requires TestFlight to be installed on the iPad and the user
-to be part of at least one group, either via Apple-ID or via public TestFlight link. The only formal requirement is iPadOS 16.
-
-Apart from that, the iPad app can also be tested via XCode and its integrated Simulator. To prevent entering the Artemis 
-credentials every time rebuilding the app while testing, just add them to your XCode environment variables. For that, click on
-the Themis icon on the top and choose "Edit Scheme...". Under "Environment Variables", add ARTEMIS_STAGING_SERVER, 
-ARTEMIS_STAGING_USER and ARTEMIS_STAGING_PASSWORD with their according values. To use the preview feature in XCode, wrap
-your preview component with an AuthenticatedPreview.
-
-For future maintenance, the existing CI/CD-Pipeline and the TestFlight account is needed.
-
-*****
-ThemisML
-*****
-
 The `ThemisML`_ system is installed on a VM which has Ubuntu 20.04 installed. The only software that has to be installed is
-`Docker`_, as explained in `this`_ tutorial.
+`Docker`_, as explained in `this tutorial <https://docs.docker.com/engine/install/ubuntu/>`_.
 
 Furthermore, a TLS/SSL certificate is needed to ensure a secure connection with the client over HTTPS. This has to be set to
 as defined in the ``docker-compose.production.yml``.
@@ -32,8 +13,8 @@ Lastly, Harbor, a registry for artifacts, needs to be configured. It stores the 
 always pull the latest in case of a deployment.
 
 .. links
+.. _ThemisML: https://github.com/ls1intum/Themis-ML
 .. _TestFlight: https://developer.apple.com/testflight/
 .. _Themis: https://github.com/ls1intum/Themis-ML
 .. _Docker: https://www.docker.com/
-.. _this: https://docs.docker.com/engine/install/ubuntu/
 .. _Harbor: https://harbor.ase.in.tum.de/

--- a/docs/admin/themisml/third-party.rst
+++ b/docs/admin/themisml/third-party.rst
@@ -16,7 +16,7 @@ Library repository SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy (1.4.46)
 Library repository Psycopg2: https://github.com/psycopg/psycopg2 (2.9.5)
 
 Feedback generation
-------------
+-------------------
 For extracting the methods, we use `ANTL4`_ for python.
 To compare code, we use `CodeBERTScore`_, which is a wrapper for CodeBERT. Because it is not available on PyPI, we directly link to the GitHub repository in our requirements.
 

--- a/docs/admin/themisml/third-party.rst
+++ b/docs/admin/themisml/third-party.rst
@@ -1,0 +1,40 @@
+Third-party Components
+===========================================
+
+Server
+------------
+ThemisML uses `FastAPI`_ for the web server and `uvicorn`_ as the ASGI server.
+
+Library repository FastAPI: https://github.com/tiangolo/fastapi (0.88.0)
+Library repository uvicorn: https://github.com/encode/uvicorn (0.20.0)
+
+Database
+------------
+To connect to the PostgreSQL database, ThemisML uses `SQLAlchemy`_ as the client and `Psycopg2`_ as the database driver.
+
+Library repository SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy (1.4.46)
+Library repository Psycopg2: https://github.com/psycopg/psycopg2 (2.9.5)
+
+Feedback generation
+------------
+For extracting the methods, we use `ANTL4`_ for python.
+To compare code, we use `CodeBERTScore`_, which is a wrapper for CodeBERT. Because it is not available on PyPI, we directly link to the GitHub repository in our requirements.
+
+Library repository ANTL4: https://github.com/antlr/antlr4 (4.11.1)
+
+Helpers
+------------
+The helper script ``determine-similarity-cutoff`` uses the `dataset`_ library to simplify working with the database.
+
+Library repository dataset: https://github.com/pudo/dataset (1.6.0)
+
+You can find the full list of third-party requirements including the most up-to-date version numbers in use in the ``requirements.txt`` files in the respective folders of the ThemisML repository. The main one is found in `feedback-suggestion/requirements.txt <https://github.com/ls1intum/Themis-ML/blob/develop/feedback-suggestion/requirements.txt>`_.
+
+.. links
+.. _FastAPI: https://fastapi.tiangolo.com/
+.. _uvicorn: https://www.uvicorn.org/
+.. _SQLAlchemy: https://www.sqlalchemy.org/
+.. _Psycopg2: https://www.psycopg.org/
+.. _ANTL4: https://www.antlr.org/
+.. _CodeBERTScore: https://github.com/neulab/code-bert-score
+.. _dataset: https://dataset.readthedocs.io/en/latest/

--- a/docs/admin/themisml/third-party.rst
+++ b/docs/admin/themisml/third-party.rst
@@ -12,8 +12,8 @@ Database
 ------------
 To connect to the PostgreSQL database, ThemisML uses `SQLAlchemy`_ as the client and `Psycopg2`_ as the database driver.
 
-Library repository SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy (1.4.46)
-Library repository Psycopg2: https://github.com/psycopg/psycopg2 (2.9.5)
+| Library repository SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy (1.4.46)
+| Library repository Psycopg2: https://github.com/psycopg/psycopg2 (2.9.5)
 
 Feedback generation
 -------------------

--- a/docs/analysis/analysis-object-model.rst
+++ b/docs/analysis/analysis-object-model.rst
@@ -2,7 +2,6 @@ Analysis Object Model
 ===========================================
 
 The Analysis Object Model describe the static structure of the system by means of classes, attributes and associations.
-| 
 
 .. image:: ../images/class_diagram.png
 

--- a/docs/analysis/dynamic-model.rst
+++ b/docs/analysis/dynamic-model.rst
@@ -6,10 +6,10 @@ This section focuses on the dynamic behavior of the system. UML activity diagram
 Since it is crucial to show the dynamic behavior of both *Themis* as well as for the *Themis machine learning component*, this section will be divided into two parts.
 
 ****
-Themis app
+Themis App
 ****
 
-Answering student questions
+Answering Student Questions
 ------------
 
 .. image:: ../images/activity_diagram_1.png
@@ -23,7 +23,7 @@ This activity diagram shows how the flow of answering a student question on a ce
 5. If otherwise, the tutor is done.
 
 
-Assessing student submissions
+Assessing Student Submissions
 ------------
 
 .. image:: ../images/activity_diagram_2.png
@@ -42,10 +42,10 @@ This activity diagram shows the workflow of assessing student submissions in the
 
 
 ****
-ThemisML Server
+ThemisML
 ****
 
-Generating feedback suggestions
+Generating Feedback Suggestions
 ------------
 
 .. image:: ../images/activity_diagram_ml.png

--- a/docs/analysis/dynamic-model.rst
+++ b/docs/analysis/dynamic-model.rst
@@ -5,12 +5,12 @@ This section focuses on the dynamic behavior of the system. UML activity diagram
 
 Since it is crucial to show the dynamic behavior of both *Themis* as well as for the *Themis machine learning component*, this section will be divided into two parts.
 
-****
+**********
 Themis App
-****
+**********
 
 Answering Student Questions
-------------
+---------------------------
 
 .. image:: ../images/activity_diagram_1.png
 
@@ -24,7 +24,7 @@ This activity diagram shows how the flow of answering a student question on a ce
 
 
 Assessing Student Submissions
-------------
+-----------------------------
 
 .. image:: ../images/activity_diagram_2.png
 
@@ -41,12 +41,12 @@ This activity diagram shows the workflow of assessing student submissions in the
 9. If there are no more open assessments left, the tutor cancels the assessment mode and is done.
 
 
-****
+********
 ThemisML
-****
+********
 
 Generating Feedback Suggestions
-------------
+-------------------------------
 
 .. image:: ../images/activity_diagram_ml.png
 

--- a/docs/analysis/dynamic-model.rst
+++ b/docs/analysis/dynamic-model.rst
@@ -42,7 +42,7 @@ This activity diagram shows the workflow of assessing student submissions in the
 
 
 ****
-Themis ML Server
+ThemisML Server
 ****
 
 Generating feedback suggestions

--- a/docs/analysis/dynamic-model.rst
+++ b/docs/analysis/dynamic-model.rst
@@ -15,7 +15,7 @@ Answering Student Questions
 .. image:: ../images/activity_diagram_1.png
 
 This activity diagram shows how the flow of answering a student question on a certain exercise e.g. during the lecture looks like. Assume that the tutor already opened the app and navigated to the corresponding lecture course.
-|
+
 1. The tutor navigates to the specific exercise.
 2. If there are no questions from any student, the tutor is done. Otherwise, the tutor searches for the student's submission.
 3. Then, the tutor opens the submission in *read-mode*.
@@ -29,7 +29,7 @@ Assessing Student Submissions
 .. image:: ../images/activity_diagram_2.png
 
 This activity diagram shows the workflow of assessing student submissions in the app. Assume that the tutor already opened the app and navigated to the corresponding lecture course.
-|
+
 1. The tutor navigates to the specific exercise.
 2. If there are no open assessments left, the tutor is done.
 3. If otherwise, the tutor starts the assessment of submissions. The tutor receives a random student submission in return.
@@ -51,7 +51,7 @@ Generating Feedback Suggestions
 .. image:: ../images/activity_diagram_ml.png
 
 This activity diagram shows the process of generating feedback suggestions.
-|
+
 1. First, the submissions are loaded from the Themis notification request.
 2. Then, the function blocks of each submission are extracted. This results in a list of function blocks.
 3. Afterwards the similarity scores between the extracted function blocks and the function blocks that are stored in the database are computed.

--- a/docs/analysis/ui.rst
+++ b/docs/analysis/ui.rst
@@ -8,7 +8,7 @@ Initial Mockups
 ***************
 
 The high-fidelity mockups below show the initial design draft for Themis. They focus on the assessment view and display the main
-workflow using the iPad app. The view is mainly divided into three parts horizontally, including a filetree sidebar,
+workflow using the iPad app. The view is mainly divided into three parts horizontally, including a file tree sidebar,
 the code viewer as well as a correction sidebar (from left to right). Within the code viewer, tutors can highlight
 specific lines of code and provide feedback. After finishing the assessment, the tutor can submit the feedback and
 either jump to the next submission or stop assessing.
@@ -36,7 +36,7 @@ Current Design
 The current design is shown below. Starting with the course view, the tutor sees all exercises a course contains as
 well as the corresponding information. Within each exercise, general statistics about the exercise are provided alongside
 with the open submissions. While assessing, the tutor can give feedback using correction guidelines. An overview of all
-feedback is listed in the correction sidbar (right side). Before finishing the assessment, the tutor can either save or
+feedback is listed in the correction sidebar (right side). Before finishing the assessment, the tutor can either save or
 submit the current feedback.
 
 

--- a/docs/analysis/ui.rst
+++ b/docs/analysis/ui.rst
@@ -2,7 +2,7 @@ User Interface
 ===========================================
 
 Initial Mockups
-********
+***************
 
 The high-fidelity mockups below show the initial design draft for Themis. They focus on the assessment view and display the main
 workflow using the iPad app. The view is mainly divided into three parts horizontally, including a filetree sidebar,
@@ -28,7 +28,7 @@ either jump to the next submission or stop assessing.
 
 
 Current Design
-********
+**************
 
 The current design is shown below. Starting with the course view, the tutor sees all exercises a course contains as
 well as the corresponding information. Within each exercise, general statistics about the exercise are provided alongside
@@ -66,4 +66,3 @@ submit the current feedback.
 |                                                           |                                                                |
 |   *Assessment view (save)*                                |       *Assessment view (submit)*                               |
 +-----------------------------------------------------------+----------------------------------------------------------------+
-

--- a/docs/analysis/ui.rst
+++ b/docs/analysis/ui.rst
@@ -1,6 +1,9 @@
 User Interface
 ===========================================
 
+.. something in general about the ui
+The user interface of Themis is designed to be as intuitive as possible. The main goal is to provide a simple and easy to use interface for tutors to assess programming exercises.
+
 Initial Mockups
 ***************
 

--- a/docs/analysis/use-case-model.rst
+++ b/docs/analysis/use-case-model.rst
@@ -2,18 +2,12 @@ Use Case Model
 ===========================================
 
 This section describes the functional behavior of the system as seen by the user. For this, UML use case diagrams are very suitable and show the interaction between the user and the system. In this setting, there are two systems and two different actors. 
-|
 
 .. image:: ../images/use_case_diagram.png
+
 |
 
 Themis is the system the tutor interacts with. A tutors main use cases are searching for a student submission, requesting a random submission and providing feedback.
 The *provide feedback* use case includes the *submit assessment* use case since it is not possible to provide the student with feedback without submitting the exercise previously.
 As a tutor might provide the student with code specific or general feedback, the corresponding use cases inherit from the *provide feedback* use case.
 Providing students with feedback also includes evaluating the automatic feedback suggestions.
-
-
-
-
-
-

--- a/docs/backlog/backlog.rst
+++ b/docs/backlog/backlog.rst
@@ -18,8 +18,8 @@ The following is a highlight of the most significant backlog items that have bee
 * Implement functionality to continue the assessment of a previously saved/submitted assessment
 * Implement view that is used for the assessment workflow
 
-  - Show an expandable filetree of the submissions repository that allows selecting files
-  - Show all opened files as dismissable/rearrangeable tabs above the code editor
+  - Show an expandable file tree of the submissions repository that allows selecting files
+  - Show all opened files as dismissable / rearrangeable tabs above the code editor
   - Show the source code of the selected file in a code editor
 
     + Apply dynamic syntax highlighting based on the file extension

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv', '.venv']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,5 @@ Themis: Artemis Tutor Grading App for iPad
     :includehidden:
     :maxdepth: 3
     
-    admin/infrastructure
-    admin/deployment
+    admin/index
     admin/issues
-    admin/third-party

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,5 +52,6 @@ Themis: Artemis Tutor Grading App for iPad
     :includehidden:
     :maxdepth: 3
     
-    admin/index
+    admin/app/index
+    admin/themisml/index
     admin/issues

--- a/docs/requirements/visionary.rst
+++ b/docs/requirements/visionary.rst
@@ -5,29 +5,25 @@ In the following, the requirements of the Themis app are explained by means of v
 
 | Anna: Tutor in the iPraktikum’s intro course
 | Tim: Tutor in the lecture-based course Patterns in Software Engineering
+
 | 
 
 **Scenario 1: Inspect student submissions for programming exercises**
-| 
 
 Anna is asked by a student, why the latest submission does not pass a specific automatic test. Anna opens the app on her iPad and navigates to the latest submission of the student. On the left of the screen a file tree of all the files in the student’s repository is displayed. Anna taps on the first file. The app opens the file and displays the source code in the editor alongside the file tree. The editor also supports syntax highlighting, which helps Anna to understand the code and how it is structured quickly. Anna does not find any issues in the first file, so she taps on the next file in the file tree and the corresponding source code is displayed in the editor view. In this file, Anna notices that the student returns the wrong value inside a function. The student can easily correct the mistake and submit again.
 
 | 
 
 **Scenario 2: Assess student submissions by giving (inline) feedback**
-| 
 
 Tim is assigned for correcting the programming exercises of the Patterns in Software Engineering exam. He opens the app and navigates to one of the exam’s programming exercises. The app shows details about the specific exercise such as its task description and statistics indicating how many submissions still need to be assessed. As the currently selected exercise still has submissions that are not assessed yet, Tim taps on a button stating Assess next submission.
-| 
 
 As a result, the app opens one of the unassessed student submission in its editor view. Tim looks through the student’s code and identifies that the wrong software pattern was implemented for the task. Therefore, he uses his stylus to input an individual, handwritten feedback for the student, which the application immediately transforms to text. Tim also assigns a score reduction of three points to this general feedback.
-| 
 
 Tim wants to give inline feedback to a specific code segment. He simply selects the lines of codes he wants to give feedback for. The editor then visually indicates the selected code segment and also provides a popup allowing Tim to enter the feedback and corresponding score reduction. Tim has no more feedback to give to the current submission, so he taps on the submit button.
 
 |
 
 **Scenario 3: Provide automatic feedback suggestions**
-|
 
 Anna wants to assess the latest available homework submission. She opens the app, navigates to the first homework exercise. Besides the exercise task description, the app also displays a button to assess the next submission, which Anna taps. The app loads the corresponding submission and displays the file tree. A feedback icon is shown next to some of the filenames. This indicates that automatic feedback suggestions are available for these files. Anna taps on the first file appended with such an icon and the corresponding source code is shown in the editor. Additionally, some of the code segments are highlighted to indicate the existence for automatic feedback suggestions. Anna taps on the first suggestions and the app opens a popup showing the proposed feedback. Anna reads the feedback and concludes that it is also suitable for the current student’s code segment, so she taps a button to use the feedback as well.

--- a/docs/system/access-control.rst
+++ b/docs/system/access-control.rst
@@ -3,15 +3,15 @@ Access Control and Security
 
 .. Access control and security describes the user model of the system in terms of an access matrix. This section also describes security issues, such as the selection of an authentication mechanism, the use of encryption, and the management of keys. This section is optional. It should be included if the non-functional requirements include security concerns. For details refer to section 7.4.3 in Prof. Bruegge's book.
 
-*****
+**********
 Themis App
-*****
+**********
 
-In order to make requests to the Artemis server the user has to be authenticated, i.e. has to have a cookie which contains a jwt token. The corresponding cookie is set by the Artemis server when calling the `/authenticate`_ route. In iOS cookies are stored and managed in the `HTTPCookieStorage`_, which means no further management of the token is done by Themis.
+In order to make requests to the Artemis server the user has to be authenticated, i.e. has to have a cookie which contains a jwt token. The corresponding cookie is set by the Artemis server when calling the `/authenticate`_ route. In iOS cookies are stored and managed in the ``HTTPCookieStorage``, which means no further management of the token is done by Themis.
 
-*****
+********
 ThemisML
-*****
+********
 
 When notifying or requesting feedback suggestions from ThemisML, the request has to contain the jwt token for Artemis of the requesting user. ThemisML only uses the token to make requests to the Artemis server and does not store the token.
 

--- a/docs/system/access-control.rst
+++ b/docs/system/access-control.rst
@@ -1,3 +1,4 @@
+.. _Access Control and Security:
 Access Control and Security
 ===========================================
 

--- a/docs/system/access-control.rst
+++ b/docs/system/access-control.rst
@@ -4,7 +4,7 @@ Access Control and Security
 .. Access control and security describes the user model of the system in terms of an access matrix. This section also describes security issues, such as the selection of an authentication mechanism, the use of encryption, and the management of keys. This section is optional. It should be included if the non-functional requirements include security concerns. For details refer to section 7.4.3 in Prof. Bruegge's book.
 
 *****
-Themis iPad App
+Themis App
 *****
 
 In order to make requests to the Artemis server the user has to be authenticated, i.e. has to have a cookie which contains a jwt token. The corresponding cookie is set by the Artemis server when calling the `/authenticate`_ route. In iOS cookies are stored and managed in the `HTTPCookieStorage`_, which means no further management of the token is done by Themis.

--- a/docs/system/data-management.rst
+++ b/docs/system/data-management.rst
@@ -11,9 +11,9 @@ The app stores the authentication cookie in the HTTPCookieStorage, which is desc
 UserDefaults
 ------------
 
-The app stores the selected Course ID in the UserDefaults at **"shownCourseIDKey"** in order to always show the last selected
+The app stores the selected Course ID (which are the ones provided by Artemis) in the UserDefaults at **"shownCourseIDKey"** in order to always show the last selected
 course.
-The Artemis-Server URL is also stored in the UserDefaults at **"serverURL"**.
+The Artemis server URL is also stored in the UserDefaults at **"serverURL"**.
 
 
 ********

--- a/docs/system/data-management.rst
+++ b/docs/system/data-management.rst
@@ -1,9 +1,9 @@
 Persistent Data Management
 ===========================================
 
-*****
+**********
 Themis App
-*****
+**********
 
 The app stores the authentication Cookie in the HTTPCookieStorage which is described in the Access Control and Security Chapter.
 
@@ -16,9 +16,9 @@ course.
 The Artemis-Server URL is also stored in the UserDefaults at **"serverURL"**.
 
 
-*****
+********
 ThemisML
-*****
+********
 ThemisML has a Postgres database separate from the Artemis database to store existing feedbacks for given submissions. The choice of the database follows a related project to ThemisML, `Athene`_.
 In principle, ThemisML could use the Artemis database directly, but the development team decided to use a separate database for a faster development cycle and more flexibility. The database might be merged in the future.
 

--- a/docs/system/data-management.rst
+++ b/docs/system/data-management.rst
@@ -5,7 +5,7 @@ Persistent Data Management
 Themis App
 **********
 
-The app stores the authentication cookie in the HTTPCookieStorage, which is described in the Access Control and Security Chapter.
+The app stores the authentication cookie in the HTTPCookieStorage, which is described in the :ref:`Access Control and Security<Access Control and Security>` Chapter.
 
 
 UserDefaults

--- a/docs/system/data-management.rst
+++ b/docs/system/data-management.rst
@@ -2,7 +2,7 @@ Persistent Data Management
 ===========================================
 
 *****
-Themis iPad App
+Themis App
 *****
 
 The app stores the authentication Cookie in the HTTPCookieStorage which is described in the Access Control and Security Chapter.
@@ -17,7 +17,7 @@ The Artemis-Server URL is also stored in the UserDefaults at **"serverURL"**.
 
 
 *****
-ThemisML Server
+ThemisML
 *****
 ThemisML has a Postgres database separate from the Artemis database to store existing feedbacks for given submissions. The choice of the database follows a related project to ThemisML, `Athene`_.
 In principle, ThemisML could use the Artemis database directly, but the development team decided to use a separate database for a faster development cycle and more flexibility. The database might be merged in the future.

--- a/docs/system/data-management.rst
+++ b/docs/system/data-management.rst
@@ -5,7 +5,7 @@ Persistent Data Management
 Themis App
 **********
 
-The app stores the authentication Cookie in the HTTPCookieStorage which is described in the Access Control and Security Chapter.
+The app stores the authentication cookie in the HTTPCookieStorage, which is described in the Access Control and Security Chapter.
 
 
 UserDefaults

--- a/docs/system/hw-sw-mapping.rst
+++ b/docs/system/hw-sw-mapping.rst
@@ -2,17 +2,17 @@ Hardware/Software Mapping
 ===========================================
 
 The diagram below shows the hardware and software mapping of the system.
-Themis is used by tutors on an iPad. Feedback suggestions are provided by the Assessment subsystem within the app which depends 
-on the Submissions Subsystem of the Artemis Server and the Automatic Feedback Subsystem of the Themis-ML Server.
+Themis is used by tutors on an iPad. Feedback suggestions are provided by the **Assessment Subsystem** within the app which depends 
+on the **Submissions Subsystem** of the **Artemis Server** and the **Automatic Feedback Subsystem** of the **Themis-ML Server**.
 Communication between nodes are facilitated by REST API.
-Please refer to `Artemis docs`_ and `Themis-ML`_ for more details regarding its deployment.
+Please refer to `Artemis documentation`_ and :ref:`Themis-ML<themisml-deployment>` for more details regarding its deployment.
 
-Artemis' Submissions Subsystem depends on an Exercise Subsystem within the server, 
+Artemis' **Submissions Subsystem** depends on an **Exercise Subsystem** within the server, 
 which provides service for managing programming exercises and their configuration. 
-This subsystem in turn requires Themis' Automatic Feedback Subsystem, 
+This subsystem in turn requires Themis' **Automatic Feedback Subsystem** , 
 which provides a tutor's feedback for a given submission. 
 
-Themis' Assessment Subsystem also requires the Automatic Feedback Subsystem of the Themis-ML server in order to provide feedback suggestions to the tutor.
+Themis' **Assessment Subsystem** also requires the **Automatic Feedback Subsystem** of the **Themis-ML** server in order to provide feedback suggestions to the tutor.
 
 
 .. figure:: ../images/deployment_diagram.png
@@ -23,5 +23,4 @@ Themis' Assessment Subsystem also requires the Automatic Feedback Subsystem of t
    *Deployment overview*
 
 
-.. _Artemis docs: https://docs.artemis.cit.tum.de/dev/system-design/#deployment
-.. _Themis-ML: https://ls1intum.github.io/Themis/admin/deployment/
+.. _Artemis documentation: https://docs.artemis.cit.tum.de/dev/system-design/#deployment

--- a/docs/system/overview.rst
+++ b/docs/system/overview.rst
@@ -10,6 +10,6 @@ Typically, a tutor will open the Themis app on their iPad and log in to the Arte
 Once logged in, they can choose a course and an exercise from the respective lists of available courses and exercises. The tutor can then start the exercise and begin grading student submissions.
 When opening a submission, the app will initiate a request to ThemisML, which is authenticated with the very same token that's used for the connection to Artemis. ThemisML will then request the submission from the Artemis server (of which the URL is included in the request) and return a list of feedback suggestions.
 
-After the tutor submitted the assessment, the app will send a request to each Artemis with the submission as well as the ThemisML server with the ID so that ThemisML can update its internal state.
+After the tutor submitted the assessment, the app will send a request to Artemis with the submission. Also, the ThemisML server will be notified with the ID so that it can update its internal state.
 
 The ThemisML server can be deployed independently from Artemis.

--- a/docs/system/overview.rst
+++ b/docs/system/overview.rst
@@ -2,6 +2,7 @@ Overview
 ===========================================
 
 .. Include and describe the Workflow here in terms of the main components and technologies used.
+
 Themis is a native iPad app using SwiftUI, which mainly communicates with Artemis-Servers via REST calls.
 It also communicates with a ThemisML server written in Python for the feedback suggestions feature.
 

--- a/docs/system/subsystem-decomposition.rst
+++ b/docs/system/subsystem-decomposition.rst
@@ -10,7 +10,7 @@ The system can be divided into four major subsystems.
 The **Exercise Subsystem** is provided by Artemis and contains the Course and Exercise components. The dependency between an exercise and its' corresponding course is modeled as shown.
 This subsystem provides the *Task Processing Service* to the **Submission Subsystem** that allows the access to an exercise in order to work on it.
 
-The **Submission Subsystem** is also provided by Artemsi and contains the Student and Submission components with the Submission component depending on the Student.
+The **Submission Subsystem** is also provided by Artemis and contains the Student and Submission components with the Submission component depending on the Student.
 
 The **Assessment Subsystem** contains the Feedback component that depends on the Guidelines and the Tests. It provides the *Feedback Service* to the **Submission Subsystem** and enables the addition of feedback to a submission.
 

--- a/docs/system/subsystem-decomposition.rst
+++ b/docs/system/subsystem-decomposition.rst
@@ -6,13 +6,12 @@ This section aims to describe the top-level view of the system in terms of compo
 .. image:: ../images/component_diagram.png
 
 The system can be divided into four major subsystems. 
-|
 
 The **Exercise Subsystem** is provided by Artemis and contains the Course and Exercise components. The dependency between an exercise and its' corresponding course is modeled as shown.
 This subsystem provides the *Task Processing Service* to the **Submission Subsystem** that allows the access to an exercise in order to work on it.
-|
+
 The **Submission Subsystem** is also provided by Artemsi and contains the Student and Submission components with the Submission component depending on the Student.
-|
+
 The **Assessment Subsystem** contains the Feedback component that depends on the Guidelines and the Tests. It provides the *Feedback Service* to the **Submission Subsystem** and enables the addition of feedback to a submission.
-|
+
 The **Automatic Feedback Subsystem** represents the machine learning component of the system. Inside, it contains the FeedbackModel and the FeedbackSuggestions components. The FeedbackModel provides the *Similarity Computation Service* to the FeedbackSuggestions. The subsystem in return provides the *Notification Service* to the **Submission Subsystem** and the *Feedback Suggestions Service* to the **Assessment Subsystem**.

--- a/docs/system/subsystem-decomposition.rst
+++ b/docs/system/subsystem-decomposition.rst
@@ -1,17 +1,17 @@
 Subsystem Decomposition
 ===========================================
 
-This section aims to describe the top-level view of the system in terms of components, subsystmes and the dependencies among components respectively subsystems.
+This section aims to describe the top-level view of the system in terms of components, subsystems and the dependencies among components, respectively subsystems.
 
 .. image:: ../images/component_diagram.png
 
 The system can be divided into four major subsystems. 
 
-The **Exercise Subsystem** is provided by Artemis and contains the Course and Exercise components. The dependency between an exercise and its' corresponding course is modeled as shown.
-This subsystem provides the *Task Processing Service* to the **Submission Subsystem** that allows the access to an exercise in order to work on it.
+The **Exercise Subsystem** is provided by Artemis and contains the **Course** and **Exercise** components. The dependency between an exercise and its corresponding course is modeled as shown.
+This subsystem provides the *Task Processing Service* to the **Submission Subsystem** that allows access to an exercise in order to work on it.
 
-The **Submission Subsystem** is also provided by Artemis and contains the Student and Submission components with the Submission component depending on the Student.
+The **Submission Subsystem** is also provided by Artemis and contains the **Student** and **Submission** components with the **Submission** component depending on the **Student**.
 
-The **Assessment Subsystem** contains the Feedback component that depends on the Guidelines and the Tests. It provides the *Feedback Service* to the **Submission Subsystem** and enables the addition of feedback to a submission.
+The **Assessment Subsystem** contains the **Feedback** component that depends on the **Guidelines** and the **Tests**. It provides the *Feedback Service* to the **Submission Subsystem** and enables the addition of feedback to a submission.
 
-The **Automatic Feedback Subsystem** represents the machine learning component of the system. Inside, it contains the FeedbackModel and the FeedbackSuggestions components. The FeedbackModel provides the *Similarity Computation Service* to the FeedbackSuggestions. The subsystem in return provides the *Notification Service* to the **Submission Subsystem** and the *Feedback Suggestions Service* to the **Assessment Subsystem**.
+The **Automatic Feedback Subsystem** represents the machine learning component of the system. Inside, it contains the **FeedbackModel** and the **FeedbackSuggestions** components. The **FeedbackModel** provides the *Similarity Computation Service* to the **FeedbackSuggestions**. The subsystem in return provides the *Notification Service* to the **Submission Subsystem** and the *Feedback Suggestions Service* to the **Assessment Subsystem**.


### PR DESCRIPTION
- restructured administrator manual to be split into two sections (Themis App & ThemisML)
- more consistency about the name "ThemisML" (no space, usually no "server" except where explicitly meant)
- fix Sphinx build warnings (broken links, wrong indentations, too few headline underline-characters)
- more consistent capitalization of headings