### PR TITLE
2 Mini-Improvements for the Documentation PDF output

### DIFF
--- a/docs/analysis/ui.rst
+++ b/docs/analysis/ui.rst
@@ -42,12 +42,41 @@ submit the current feedback.
 
 
 +-----------------------------------------------------------+----------------------------------------------------------------+
+| .. figure:: ../images/mockup_assessment.png               |  .. figure:: ../images/mockup_feedback.png                     |
+|   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
+|   :width: 450                                             |       :width: 450                                              |
+|   :align: center                                          |       :align: center                                           |
+|                                                           |                                                                |
+|   *Assessment view (highlighted code)*                    |       *Assessment view (feedback)*                             |
++-----------------------------------------------------------+----------------------------------------------------------------+
+| .. figure:: ../images/mockup_submit.png                   |  .. figure:: ../images/mockup_next-action.png                  |
+|   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
+|   :width: 450                                             |       :width: 450                                              |
+|   :align: center                                          |       :align: center                                           |
+|                                                           |                                                                |
+|   *Assessment view (submit)*                              |       *Assessment view (next action)*                          |
++-----------------------------------------------------------+----------------------------------------------------------------+
+
+
+Current Design
+**************
+
+The current design is shown below. Starting with the course view, the tutor sees all exercises a course contains as
+well as the corresponding information. Within each exercise, general statistics about the exercise are provided alongside
+with the open submissions. While assessing, the tutor can give feedback using correction guidelines. An overview of all
+feedback is listed in the correction sidebar (right side). Before finishing the assessment, the tutor can either save or
+submit the current feedback.
+
+
++-----------------------------------------------------------+----------------------------------------------------------------+
 | .. figure:: ../images/design_course.png                   |  .. figure:: ../images/design_exercise.png                     |
 |   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
 |   :width: 450                                             |       :width: 450                                              |
 |   :align: center                                          |       :align: center                                           |
 |                                                           |                                                                |
 |   *Course view*                                           |       *Exercise view*                                          |
++-----------------------------------------------------------+----------------------------------------------------------------+
+
 +-----------------------------------------------------------+----------------------------------------------------------------+
 | .. figure:: ../images/design_assessment.png               |  .. figure:: ../images/design_feedback.png                     |
 |   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
@@ -56,12 +85,16 @@ submit the current feedback.
 |                                                           |                                                                |
 |   *Assessment view*                                       |       *Assessment view (feedback)*                             |
 +-----------------------------------------------------------+----------------------------------------------------------------+
+
++-----------------------------------------------------------+----------------------------------------------------------------+
 | .. figure:: ../images/design_guidelines.png               |  .. figure:: ../images/design_feedback-list.png                |
 |   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
 |   :width: 450                                             |       :width: 450                                              |
 |   :align: center                                          |       :align: center                                           |
 |                                                           |                                                                |
 |   *Assessment view (correction guidelines)*               |       *Assessment view (feedback overview)*                    |
++-----------------------------------------------------------+----------------------------------------------------------------+
+
 +-----------------------------------------------------------+----------------------------------------------------------------+
 | .. figure:: ../images/design_save.png                     |  .. figure:: ../images/design_submit.png                       |
 |   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |

--- a/docs/analysis/ui.rst
+++ b/docs/analysis/ui.rst
@@ -42,33 +42,6 @@ submit the current feedback.
 
 
 +-----------------------------------------------------------+----------------------------------------------------------------+
-| .. figure:: ../images/mockup_assessment.png               |  .. figure:: ../images/mockup_feedback.png                     |
-|   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
-|   :width: 450                                             |       :width: 450                                              |
-|   :align: center                                          |       :align: center                                           |
-|                                                           |                                                                |
-|   *Assessment view (highlighted code)*                    |       *Assessment view (feedback)*                             |
-+-----------------------------------------------------------+----------------------------------------------------------------+
-| .. figure:: ../images/mockup_submit.png                   |  .. figure:: ../images/mockup_next-action.png                  |
-|   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
-|   :width: 450                                             |       :width: 450                                              |
-|   :align: center                                          |       :align: center                                           |
-|                                                           |                                                                |
-|   *Assessment view (submit)*                              |       *Assessment view (next action)*                          |
-+-----------------------------------------------------------+----------------------------------------------------------------+
-
-
-Current Design
-**************
-
-The current design is shown below. Starting with the course view, the tutor sees all exercises a course contains as
-well as the corresponding information. Within each exercise, general statistics about the exercise are provided alongside
-with the open submissions. While assessing, the tutor can give feedback using correction guidelines. An overview of all
-feedback is listed in the correction sidebar (right side). Before finishing the assessment, the tutor can either save or
-submit the current feedback.
-
-
-+-----------------------------------------------------------+----------------------------------------------------------------+
 | .. figure:: ../images/design_course.png                   |  .. figure:: ../images/design_exercise.png                     |
 |   :alt: Deployment diagram of Themis                      |       :alt: Deployment diagram of Themis                       |
 |   :width: 450                                             |       :width: 450                                              |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 
 project = 'Themis'
 copyright = '2023, Technical University of Munich, Chair for Applied Software Engineering'
-author = 'Technical University of Munich, Chair for Applied Software Engineering'
+author = 'Chair for Applied Software Engineering, TUM'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
- split UI screenshots onto different pages
- shorter author name

resulting PDF:
[themis.pdf](https://github.com/ls1intum/Themis/files/10755687/themis.pdf)


