### PR TITLE
Use correct SwiftLint config file for GH Action

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: GitHub Action for SwiftLint (Only files changed in the PR)
         uses: ezraberch/action-swiftlint@3.2.3
         with:
-          swiftlint-args: --config swiftlint.yml --strict
+          args: --config swiftlint.yml --strict
         env:
            DIFF_BASE: ${{ github.base_ref }}
            DIFF_HEAD: HEAD

--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -78,7 +78,7 @@ struct FiletreeSidebarView: View {
     @ViewBuilder
     private func showWarningIfNeeded() -> some View {
         if repositorySelection != .student && !assessmentVM.readOnly {
-            ArtemisHintBox(text: "Some functionality may be limited while viewing this repository")
+            ArtemisHintBox(text: "Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository.")
                 .padding(.horizontal)
         }
     }

--- a/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
+++ b/Themis/Views/Assessment/FiletreeSidebar/FiletreeSidebarView.swift
@@ -78,7 +78,7 @@ struct FiletreeSidebarView: View {
     @ViewBuilder
     private func showWarningIfNeeded() -> some View {
         if repositorySelection != .student && !assessmentVM.readOnly {
-            ArtemisHintBox(text: "Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository. Some functionality may be limited while viewing this repository.")
+            ArtemisHintBox(text: "Some functionality may be limited while viewing this repository")
                 .padding(.horizontal)
         }
     }


### PR DESCRIPTION
This PR changes an incorrect argument name in the SwiftLint GH action.
After the changes, the correct SwiftLint config file (the custom one located at the root of this repository) is used for linting.