### PR TITLE
`Programming Exercise`: Use the new testCase field to show test names

### DIFF
--- a/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
@@ -21,7 +21,7 @@ struct FeedbackCellView: View {
     private var feedbackText: String {
         if let feedbackType = feedback.baseFeedback.type,
            feedbackType.isAutomatic {
-            return feedback.baseFeedback.testCase?.testName ?? "Test Case"
+            return feedback.baseFeedback.text ?? feedback.baseFeedback.testCase?.testName ?? "Test Case"
         }
         return feedback.baseFeedback.text ?? "Feedback"
     }

--- a/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
@@ -18,7 +18,13 @@ struct FeedbackCellView: View {
     @State var feedback: AssessmentFeedback
     private var editingDisabled: Bool { assessmentVM.readOnly || !assessmentVM.allowsInlineFeedbackOperations }
     private var tapGestureDisabled: Bool { feedback.scope != .inline || !assessmentVM.allowsInlineFeedbackOperations }
-    private var feedbackText: String {feedback.baseFeedback.text ?? feedback.baseFeedback.testCase?.testName ?? "Feedback"}
+    private var feedbackText: String {
+        if let feedbackType = feedback.baseFeedback.type,
+           feedbackType.isAutomatic {
+            return feedback.baseFeedback.testCase?.testName ?? "Test Case"
+        }
+        return feedback.baseFeedback.text ?? "Feedback"
+    }
     private var feedbackDetailText: String {feedback.baseFeedback.detailText ?? ""}
 
     @State var showEditFeedback = false

--- a/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
+++ b/Themis/Views/Assessment/CorrectionSidebar/FeedbackCellView.swift
@@ -18,7 +18,9 @@ struct FeedbackCellView: View {
     @State var feedback: AssessmentFeedback
     private var editingDisabled: Bool { assessmentVM.readOnly || !assessmentVM.allowsInlineFeedbackOperations }
     private var tapGestureDisabled: Bool { feedback.scope != .inline || !assessmentVM.allowsInlineFeedbackOperations }
-    
+    private var feedbackText: String {feedback.baseFeedback.text ?? feedback.baseFeedback.testCase?.testName ?? "Feedback"}
+    private var feedbackDetailText: String {feedback.baseFeedback.detailText ?? ""}
+
     @State var showEditFeedback = false
     
     var participationId: Int?
@@ -31,7 +33,7 @@ struct FeedbackCellView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack {
-                Text(feedback.baseFeedback.text ?? "Feedback")
+                Text(feedbackText)
                     .foregroundColor(.getTextColor(forCredits: feedback.baseFeedback.credits ?? 0.0))
                 
                 Spacer()
@@ -43,7 +45,7 @@ struct FeedbackCellView: View {
                 .frame(maxWidth: .infinity)
             
             HStack {
-                Text(feedback.baseFeedback.detailText ?? "")
+                Text(feedbackDetailText)
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(.getTextColor(forCredits: feedback.baseFeedback.credits ?? 0.0))


### PR DESCRIPTION
This PR is an adaptation for the change implemented in: https://github.com/ls1intum/Artemis/pull/7015 and can be merged before the relevant PR since it is backwards-compatible.

Previously, we were using the `feedback.text` field of feedbacks to get the test name. With this PR, we use `feedback.testCase.testName` if the `text` field is nil.