### PR TITLE
`Programming Exercise`: Add rated field to the assessment result

### DIFF
--- a/Themis/Models/Result/ProgrammingAssessmentResult.swift
+++ b/Themis/Models/Result/ProgrammingAssessmentResult.swift
@@ -19,6 +19,7 @@ struct ProgrammingAssessmentResultDTO: Encodable {
     let feedbacks: [Feedback]
     let testCaseCount: Int
     let passedTestCaseCount: Int
+    let rated = true
     
     init(basedOn programmingAssessmentResult: ProgrammingAssessmentResult) {
         self.score = programmingAssessmentResult.score


### PR DESCRIPTION
Previously the `rated` field was not being sent when submitting assessments. Because of this, the web client was not registering submitted assessments and the counter shown below was not being incremented:
<img width="210" alt="Screenshot 2023-10-09 at 22 25 32" 
src="https://github.com/ls1intum/Themis/assets/22798314/e05ae0ba-277c-4913-bdc8-3dcd39b00eba">

This could also have some other consequences for the assessment process in general. Therefore, I added the aforementioned field.