### PR TITLE
`Programming Exercise`: Make highlights covering whole lines visible again

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		65B9BD042AAE15110086F9EC /* FileUploadAssessmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B9BD032AAE15110086F9EC /* FileUploadAssessmentView.swift */; };
 		65B9BD092AAE18570086F9EC /* FileUploadAssessmentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B9BD082AAE18570086F9EC /* FileUploadAssessmentViewModel.swift */; };
 		65B9BD102AAE413B0086F9EC /* FileUploadSubmissionServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B9BD0F2AAE413B0086F9EC /* FileUploadSubmissionServiceImpl.swift */; };
+		65BA61D72AE02B5C009FE11C /* PathStringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BA61D62AE02B5C009FE11C /* PathStringExtension.swift */; };
 		65BC14532A6FD9F30002D089 /* UMLBadgeSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BC14522A6FD9F30002D089 /* UMLBadgeSymbol.swift */; };
 		65C2F7532A03E3D4001EDADC /* FormatterExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C2F7522A03E3D4001EDADC /* FormatterExtension.swift */; };
 		65C2F7552A03E428001EDADC /* JSONDecoderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C2F7542A03E428001EDADC /* JSONDecoderExtension.swift */; };
@@ -304,6 +305,7 @@
 		65B9BD032AAE15110086F9EC /* FileUploadAssessmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadAssessmentView.swift; sourceTree = "<group>"; };
 		65B9BD082AAE18570086F9EC /* FileUploadAssessmentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadAssessmentViewModel.swift; sourceTree = "<group>"; };
 		65B9BD0F2AAE413B0086F9EC /* FileUploadSubmissionServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadSubmissionServiceImpl.swift; sourceTree = "<group>"; };
+		65BA61D62AE02B5C009FE11C /* PathStringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathStringExtension.swift; sourceTree = "<group>"; };
 		65BC14522A6FD9F30002D089 /* UMLBadgeSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UMLBadgeSymbol.swift; sourceTree = "<group>"; };
 		65C2F7522A03E3D4001EDADC /* FormatterExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatterExtension.swift; sourceTree = "<group>"; };
 		65C2F7542A03E428001EDADC /* JSONDecoderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoderExtension.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 				657EBAFA2A8927E8005525AA /* SkeletonExtension.swift */,
 				65B981AE2A7BDEF800FFC2F4 /* CGPointExtension.swift */,
 				652EDCBC2AC5CAB1009D9A3C /* GeometryProxyExtension.swift */,
+				65BA61D62AE02B5C009FE11C /* PathStringExtension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1463,6 +1466,7 @@
 				DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */,
 				650D88002A7A5B78004E7533 /* UMLDiagramRenderer.swift in Sources */,
 				E21AF054292B9D4C0096ACFC /* CodeView.swift in Sources */,
+				65BA61D72AE02B5C009FE11C /* PathStringExtension.swift in Sources */,
 				E2E460DD29292ECF00ECC0A5 /* Stack.swift in Sources */,
 				A9752D7B2992AAEB004441D1 /* ExamSectionDetailView.swift in Sources */,
 				DA3F0F03294A308E00A7B807 /* EditFeedbackView.swift in Sources */,

--- a/Themis/Extensions/PathStringExtension.swift
+++ b/Themis/Extensions/PathStringExtension.swift
@@ -1,0 +1,26 @@
+//
+//  PathStringExtension.swift
+//  Themis
+//
+//  Created by Tarlan Ismayilsoy on 18.10.23.
+//
+
+import Foundation
+
+extension String {
+    /// Treats this string as a path and removes the leading slash if it exists.
+    func removeLeadingSlashIfExists() -> String {
+        if self.first == "/" {
+            return String(self.dropFirst())
+        }
+        return self
+    }
+    
+    /// Treats this string as a path and appends a leading slash if it missing.
+    func appendingLeadingSlashIfMissing() -> String {
+        if let firstChar = self.first, firstChar != "/" {
+            return "/" + self
+        }
+        return self
+    }
+}

--- a/Themis/Models/Feedback/ProgrammingFeedbackDetail.swift
+++ b/Themis/Models/Feedback/ProgrammingFeedbackDetail.swift
@@ -20,20 +20,23 @@ public struct ProgrammingFeedbackDetail: FeedbackDetail {
         if lines.location == 0 {
             return
         }
-        baseFeedback.reference = "file:" + file.path + "_line:\(lines.location)"
+        
+        let filePath = file.path.removeLeadingSlashIfExists()
+        
+        baseFeedback.reference = "file:" + filePath + "_line:\(lines.location)"
         
         guard let columns else {
             if lines.length == 0 {
-                baseFeedback.text = "File " + file.path + " at line \(lines.location)"
+                baseFeedback.text = "File " + filePath + " at line \(lines.location)"
             } else {
-                baseFeedback.text = "File " + file.path + " at lines \(lines.location)-\(lines.location + lines.length)"
+                baseFeedback.text = "File " + filePath + " at lines \(lines.location)-\(lines.location + lines.length)"
             }
             return
         }
         if columns.length == 0 {
-            baseFeedback.text = "File " + file.path + " at line \(lines.location) column \(columns.location)"
+            baseFeedback.text = "File " + filePath + " at line \(lines.location) column \(columns.location)"
         } else {
-            baseFeedback.text = "File " + file.path + " at line \(lines.location) column \(columns.location)-\(columns.location + columns.length)"
+            baseFeedback.text = "File " + filePath + " at line \(lines.location) column \(columns.location)-\(columns.location + columns.length)"
         }
     }
 }

--- a/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
@@ -277,8 +277,9 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
                         let startIndex = fileLines[lines[0] - 1].location
                         var endIndex = fileLines[lines[0] - 1].location + fileLines[lines[0] - 1].length
                         
-                        if lines[0] == fileLines.count { // if we don't do this, the highlight for the last line becomes invisible
-                            endIndex -= 1
+                        let highlightCoversLastLine = (line == fileLines.count)
+                        if highlightCoversLastLine {
+                            endIndex -= 1 // if we don't do this, the highlight for the last line becomes invisible
                         }
                         
                         range = NSRange(location: startIndex, length: endIndex - startIndex)
@@ -290,10 +291,11 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
                 let endLine = lines[1]
                 if fileLines.count >= endLine {
                     let startIndex = fileLines[startLine - 1].location
-                    var endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length - 1
+                    var endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length
                     
-                    if endLine == fileLines.count { // if we don't do this, the highlight for the last line becomes invisible
-                        endIndex -= 1
+                    let highlightEndsAtLastLine = (endLine == fileLines.count)
+                    if highlightEndsAtLastLine {
+                        endIndex -= 1 // if we don't do this, the highlight for the last line becomes invisible
                     }
                     
                     range = NSRange(location: startIndex, length: endIndex - startIndex)
@@ -310,9 +312,7 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
 extension CodeEditorViewModel {
     private func extractFilePath(textComponents: [String]) -> String {
         var filePathComponent = textComponents[1]
-        if let firstChar = filePathComponent.first, firstChar != "/" {
-            filePathComponent = "/" + filePathComponent
-        }
+        filePathComponent = filePathComponent.appendingLeadingSlashIfMissing()
         
         return filePathComponent
     }

--- a/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
@@ -251,37 +251,31 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
         }
     }
     
-    private func extractFilePath(textComponents: [String]) -> String {
-        textComponents[1]
-    }
-    
-    private func extractLines(textComponents: [String]) -> [Int] {
-        textComponents[4].components(separatedBy: "-").map { Int($0) ?? 0 }
-    }
-    
-    private func extractColumns(textComponents: [String]) -> [Int] {
-        textComponents[6].components(separatedBy: "-").map { Int($0) ?? 0 }
-    }
-    
     @MainActor
     private func constructHighlight(file: Node, lines: [Int], id: UUID, columns: [Int]? = nil) {
         if let fileLines = file.lines {
             var range = NSRange(location: 0, length: 0)
             switch lines.count {
-            // single line feedback with additional column reference
+            // single line feedback
             case 1:
                 let line = lines[0]
-                if fileLines.count >= line, let columns = columns {
-                    let leftCol = columns[0]
-                    if columns.count == 1 {
-                        // single column
-                        let startIndex = fileLines[line - 1].location + leftCol - 1
-                        range = NSRange(location: startIndex, length: 1)
-                    } else {
-                        // two columns
-                        let rightCol = columns[1]
-                        let startIndex = fileLines[line - 1].location + leftCol - 1
-                        let endIndex = fileLines[line - 1].location + rightCol - 1
+                if fileLines.count >= line {
+                    if let columns { // with additional column reference
+                        let leftCol = columns[0]
+                        if columns.count == 1 {
+                            // single column
+                            let startIndex = fileLines[line - 1].location + leftCol - 1
+                            range = NSRange(location: startIndex, length: 1)
+                        } else {
+                            // two columns
+                            let rightCol = columns[1]
+                            let startIndex = fileLines[line - 1].location + leftCol - 1
+                            let endIndex = fileLines[line - 1].location + rightCol - 1
+                            range = NSRange(location: startIndex, length: endIndex - startIndex)
+                        }
+                    } else { // without additional column reference (the whole line)
+                        let startIndex = fileLines[lines[0] - 1].location
+                        let endIndex = fileLines[lines[0] - 1].location + fileLines[lines[0] - 1].length
                         range = NSRange(location: startIndex, length: endIndex - startIndex)
                     }
                 }
@@ -291,7 +285,7 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
                 let endLine = lines[1]
                 if fileLines.count >= endLine {
                     let startIndex = fileLines[startLine - 1].location
-                    let endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length
+                    let endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length - 1
                     range = NSRange(location: startIndex, length: endIndex - startIndex)
                 }
             default:
@@ -302,6 +296,27 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
     }
 }
 
+// MARK: - Functions for extracting line and column information
+extension CodeEditorViewModel {
+    private func extractFilePath(textComponents: [String]) -> String {
+        var filePathComponent = textComponents[1]
+        if let firstChar = filePathComponent.first, firstChar != "/" {
+            filePathComponent = "/" + filePathComponent
+        }
+        
+        return filePathComponent
+    }
+    
+    private func extractLines(textComponents: [String]) -> [Int] {
+        textComponents[4].components(separatedBy: "-").map { Int($0) ?? 0 }
+    }
+    
+    private func extractColumns(textComponents: [String]) -> [Int] {
+        textComponents[6].components(separatedBy: "-").map { Int($0) ?? 0 }
+    }
+}
+
+// MARK: - Feedback Delegate
 extension CodeEditorViewModel: FeedbackDelegate {
     @MainActor
     func onFeedbackCreation(_ feedback: AssessmentFeedback) {

--- a/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
+++ b/Themis/ViewModels/Assessment/Programming/CodeEditorViewModel.swift
@@ -275,7 +275,12 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
                         }
                     } else { // without additional column reference (the whole line)
                         let startIndex = fileLines[lines[0] - 1].location
-                        let endIndex = fileLines[lines[0] - 1].location + fileLines[lines[0] - 1].length
+                        var endIndex = fileLines[lines[0] - 1].location + fileLines[lines[0] - 1].length
+                        
+                        if lines[0] == fileLines.count { // if we don't do this, the highlight for the last line becomes invisible
+                            endIndex -= 1
+                        }
+                        
                         range = NSRange(location: startIndex, length: endIndex - startIndex)
                     }
                 }
@@ -285,7 +290,12 @@ class CodeEditorViewModel: ExerciseRendererViewModel {
                 let endLine = lines[1]
                 if fileLines.count >= endLine {
                     let startIndex = fileLines[startLine - 1].location
-                    let endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length - 1
+                    var endIndex = fileLines[endLine - 1].location + fileLines[endLine - 1].length - 1
+                    
+                    if endLine == fileLines.count { // if we don't do this, the highlight for the last line becomes invisible
+                        endIndex -= 1
+                    }
+                    
                     range = NSRange(location: startIndex, length: endIndex - startIndex)
                 }
             default:


### PR DESCRIPTION
There was an issue that made inline feedback added from the web client invisible in Themis:

<img width="550" alt="Screenshot 2023-10-10 at 11 12 22" src="https://github.com/ls1intum/Themis/assets/22798314/5ad4f7d2-bf39-4e68-a031-a5d63d89cbb4">
<img width="550" alt="Screenshot 2023-10-10 at 11 12 35" src="https://github.com/ls1intum/Themis/assets/22798314/5ba2ce0c-6234-47e5-bd52-d2f87298b822">
<br></br>

This PR fixes the issue:
<img width="550" alt="Screenshot 2023-10-10 at 11 16 02" src="https://github.com/ls1intum/Themis/assets/22798314/c6371773-eb25-432e-89f8-afce1012a967">
