### PR TITLE
`Assessment View`: Prevent cancellation of submitted assessments

### DIFF
--- a/Themis/Extensions/SubmissionExtension.swift
+++ b/Themis/Extensions/SubmissionExtension.swift
@@ -18,6 +18,10 @@ extension BaseSubmission {
     func getExercise<T>(as: T.Type = (any BaseExercise).self) -> T? {
         self.getParticipation()?.getExercise(as: T.self)
     }
+    
+    var isAssessed: Bool {
+        results?.last?.completionDate != nil
+    }
 }
 
 extension Submission {

--- a/Themis/ViewModels/SubmissionList/SubmissionListViewModel.swift
+++ b/Themis/ViewModels/SubmissionList/SubmissionListViewModel.swift
@@ -15,11 +15,11 @@ class SubmissionListViewModel: ObservableObject {
     @Published var isLoading = false
     
     var submittedSubmissions: [Submission] {
-        submissions.filter { $0.baseSubmission.results?.last?.completionDate != nil }
+        submissions.filter { $0.baseSubmission.isAssessed }
     }
     
     var openSubmissions: [Submission] {
-        submissions.filter { $0.baseSubmission.results?.last?.completionDate == nil }
+        submissions.filter { !$0.baseSubmission.isAssessed }
     }
     
     private var isLoadedOnce = false

--- a/Themis/Views/Assessment/Toolbar/ToolbarCancelButton.swift
+++ b/Themis/Views/Assessment/Toolbar/ToolbarCancelButton.swift
@@ -61,18 +61,18 @@ struct ToolbarCancelButton: View {
             .foregroundColor(.white)
         }
         .confirmationDialog("Cancel Assessment", isPresented: $showCancelDialog) {
-            Button(saveButtonLabel, role: saveButtonRole) {
-                Task {
-                    await assessmentVM.saveAssessment()
-                    presentationMode.dismiss()
-                }
-            }
-            
             Button(deleteButtonLabel, role: deleteButtonRole) {
                 Task {
                     if !submissionIsAssessed {
                         await assessmentVM.cancelAssessment()
                     }
+                    presentationMode.dismiss()
+                }
+            }
+            
+            Button(saveButtonLabel, role: saveButtonRole) {
+                Task {
+                    await assessmentVM.saveAssessment()
                     presentationMode.dismiss()
                 }
             }

--- a/Themis/Views/Assessment/Toolbar/ToolbarCancelButton.swift
+++ b/Themis/Views/Assessment/Toolbar/ToolbarCancelButton.swift
@@ -13,11 +13,46 @@ struct ToolbarCancelButton: View {
     @Binding var presentationMode: PresentationMode
     @State private var showCancelDialog = false
     
+    /// Indicates that the user is viewing a submission that was previously assessed and submitted.
+    /// In this case, they can override the assessment, but can not cancel it.
+    private var submissionIsAssessed: Bool {
+        assessmentVM.submission?.isAssessed == true
+    }
+    
+    private var saveButtonLabel: String {
+        submissionIsAssessed ? "Override" : "Save"
+    }
+    
+    private var saveButtonRole: ButtonRole? {
+        submissionIsAssessed ? ButtonRole.destructive : nil
+    }
+    
+    private var deleteButtonLabel: String {
+        submissionIsAssessed ? "Discard" : "Delete"
+    }
+    
+    private var deleteButtonRole: ButtonRole? {
+        submissionIsAssessed ? nil : ButtonRole.destructive
+    }
+    
+    private var message: String {
+        if submissionIsAssessed {
+            """
+            Either discard your recent changes \
+            or override the existing assessment.
+            """
+        } else {
+            """
+            Either discard the assessment \
+            and release the lock (recommended) \
+            or keep the lock and save the assessment without submitting it.
+            """
+        }
+    }
+    
     var body: some View {
         Button {
-            Task {
-                assessmentVM.readOnly ? presentationMode.dismiss() : showCancelDialog.toggle()
-            }
+            assessmentVM.readOnly ? presentationMode.dismiss() : showCancelDialog.toggle()
         } label: {
             HStack {
                 Image(systemName: "chevron.left")
@@ -26,25 +61,23 @@ struct ToolbarCancelButton: View {
             .foregroundColor(.white)
         }
         .confirmationDialog("Cancel Assessment", isPresented: $showCancelDialog) {
-            Button("Save") {
+            Button(saveButtonLabel, role: saveButtonRole) {
                 Task {
                     await assessmentVM.saveAssessment()
                     presentationMode.dismiss()
                 }
             }
             
-            Button("Delete", role: .destructive) {
+            Button(deleteButtonLabel, role: deleteButtonRole) {
                 Task {
-                    await assessmentVM.cancelAssessment()
+                    if !submissionIsAssessed {
+                        await assessmentVM.cancelAssessment()
+                    }
                     presentationMode.dismiss()
                 }
             }
         } message: {
-            Text("""
-                 Either discard the assessment \
-                 and release the lock (recommended) \
-                 or keep the lock and save the assessment without submitting it.
-                 """)
+            Text(message)
         }
     }
 }


### PR DESCRIPTION
Closes #197 

Cancellation dialog for submitted assessments:
<img width="200" alt="assessed" src="https://github.com/ls1intum/Themis/assets/22798314/6024c4f2-b0fc-4b3c-87a7-3972d4c1a060">

Cancellation dialog for in-progress assessments:
<img width="200" alt="in assessment" src="https://github.com/ls1intum/Themis/assets/22798314/1530e682-de57-48e4-9ca6-f99262ab0a8c">

