### PR TITLE
`Programming Exercise`: Prevent selecting empty space

### DIFF
--- a/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
@@ -524,6 +524,7 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
         guard let dragSelection else { return false }
         
         // Check for empty selection
+        // Warning: This also prevents selecting an empty line, which is possible in the web client
         if let selectedRangeAsNSRange = Range(dragSelection.toNSRange(), in: self.text),
            string[selectedRangeAsNSRange].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return false

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextView.swift
@@ -79,7 +79,6 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
     }
     
     var selectionGranularity = UITextGranularity.character
-    var canSelectionIncludeHighlightedRanges = true
     
     var feedbackMode = true
     
@@ -522,11 +521,18 @@ final class UXCodeTextView: UXTextView, HighlightDelegate, UIScrollViewDelegate 
     
     /// Validates the `dragSelection` value
     private func isSelectionValid() -> Bool {
-        guard !canSelectionIncludeHighlightedRanges else { return true }
+        guard let dragSelection else { return false }
         
+        // Check for empty selection
+        if let selectedRangeAsNSRange = Range(dragSelection.toNSRange(), in: self.text),
+           string[selectedRangeAsNSRange].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return false
+        }
+        
+        // Check for overlap
         let highlightedIntRanges = highlightedRanges.compactMap({ Range($0.range) })
         for range in highlightedIntRanges {
-            if self.dragSelection?.overlaps(range) == true {
+            if dragSelection.overlaps(range) == true {
                 return false
             }
         }

--- a/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
+++ b/CodeEditor/Sources/CodeEditor/UXCodeTextViewRepresentable.swift
@@ -233,7 +233,6 @@ public struct UXCodeTextViewRepresentable: UXViewRepresentable {
         textView.pencilOnly = editorBindings.pencilOnly.wrappedValue
         textView.dragSelection = self.editorBindings.dragSelection?.wrappedValue
         textView.selectionGranularity = editorBindings.selectionGranularity
-        textView.canSelectionIncludeHighlightedRanges = editorBindings.canSelectionIncludeHighlightedRanges
         textView.font = editorBindings.font ?? textView.font
         
         if let binding = editorBindings.fontSize {

--- a/CodeEditor/Sources/CodeEditor/Utils/EditorBindings.swift
+++ b/CodeEditor/Sources/CodeEditor/Utils/EditorBindings.swift
@@ -13,7 +13,6 @@ public struct EditorBindings {
     public let indentStyle: CodeEditor.IndentStyle
     public var highlightedRanges: [HighlightedRange]
     public let selectionGranularity: UITextGranularity
-    public let canSelectionIncludeHighlightedRanges: Bool
     public var dragSelection: Binding<Range<Int>?>?
     public var showAddFeedback: Binding<Bool>
     public var showEditFeedback: Binding<Bool>
@@ -37,7 +36,6 @@ public struct EditorBindings {
                 indentStyle: CodeEditor.IndentStyle = .system,
                 highlightedRanges: [HighlightedRange],
                 selectionGranularity: UITextGranularity = .character,
-                canSelectionIncludeHighlightedRanges: Bool = true,
                 dragSelection: Binding<Range<Int>?>? = nil,
                 showAddFeedback: Binding<Bool>,
                 showEditFeedback: Binding<Bool>,
@@ -61,7 +59,6 @@ public struct EditorBindings {
         self.indentStyle = indentStyle
         self.highlightedRanges = highlightedRanges
         self.selectionGranularity = selectionGranularity
-        self.canSelectionIncludeHighlightedRanges = canSelectionIncludeHighlightedRanges
         self.dragSelection = dragSelection
         self.showAddFeedback = showAddFeedback
         self.showEditFeedback = showEditFeedback

--- a/Themis/Views/Assessment/Text Exercise/TextExerciseRenderer.swift
+++ b/Themis/Views/Assessment/Text Exercise/TextExerciseRenderer.swift
@@ -51,7 +51,6 @@ struct TextExerciseRenderer: View {
                 flags: editorFlags,
                 highlightedRanges: textExerciseRendererVM.inlineHighlights,
                 selectionGranularity: .word,
-                canSelectionIncludeHighlightedRanges: false,
                 dragSelection: $dragSelection,
                 showAddFeedback: $textExerciseRendererVM.showAddFeedback,
                 showEditFeedback: $textExerciseRendererVM.showEditFeedback,


### PR DESCRIPTION
Closes #195 

With this PR, attempting to select a range containing no character other than whitespace and newlines leads to the cancellation of the highlight.

https://github.com/ls1intum/Themis/assets/22798314/d466f2f8-ea9d-49f7-8d0c-b344a0ad6549

