### PR TITLE
`Course View and Assessment View`: Add popover tips for clarity

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		65A49CE72A558AC200F8B716 /* ExerciseHelperService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A49CE62A558AC200F8B716 /* ExerciseHelperService.swift */; };
 		65A49CE92A55AE4800F8B716 /* ModelingSubmissionServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A49CE82A55AE4800F8B716 /* ModelingSubmissionServiceImpl.swift */; };
 		65A869962AAEF5D200B89199 /* FileRendererViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A869952AAEF5D200B89199 /* FileRendererViewModel.swift */; };
+		65AB56D52ADEF60D004B5F3F /* CoursePickerTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AB56D42ADEF60D004B5F3F /* CoursePickerTip.swift */; };
+		65AB56D72ADEF6EB004B5F3F /* FeedbackModeTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AB56D62ADEF6EB004B5F3F /* FeedbackModeTip.swift */; };
 		65B49F382A07D5C000C9A45F /* ToolbarPointsLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B49F372A07D5C000C9A45F /* ToolbarPointsLabel.swift */; };
 		65B49F3A2A07D5F200C9A45F /* ToolbarToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B49F392A07D5F200C9A45F /* ToolbarToggleButton.swift */; };
 		65B49F3E2A07ED6100C9A45F /* ToolbarFileTreeToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B49F3D2A07ED6100C9A45F /* ToolbarFileTreeToggleButton.swift */; };
@@ -291,6 +293,8 @@
 		65A49CE62A558AC200F8B716 /* ExerciseHelperService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseHelperService.swift; sourceTree = "<group>"; };
 		65A49CE82A55AE4800F8B716 /* ModelingSubmissionServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelingSubmissionServiceImpl.swift; sourceTree = "<group>"; };
 		65A869952AAEF5D200B89199 /* FileRendererViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRendererViewModel.swift; sourceTree = "<group>"; };
+		65AB56D42ADEF60D004B5F3F /* CoursePickerTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePickerTip.swift; sourceTree = "<group>"; };
+		65AB56D62ADEF6EB004B5F3F /* FeedbackModeTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackModeTip.swift; sourceTree = "<group>"; };
 		65B49F372A07D5C000C9A45F /* ToolbarPointsLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarPointsLabel.swift; sourceTree = "<group>"; };
 		65B49F392A07D5F200C9A45F /* ToolbarToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarToggleButton.swift; sourceTree = "<group>"; };
 		65B49F3D2A07ED6100C9A45F /* ToolbarFileTreeToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarFileTreeToggleButton.swift; sourceTree = "<group>"; };
@@ -636,6 +640,7 @@
 				65B49F442A08064400C9A45F /* ToolbarUndoButton.swift */,
 				65B49F462A080A9900C9A45F /* ToolbarRedoButton.swift */,
 				65B49F482A0817DC00C9A45F /* ToolbarSaveButton.swift */,
+				65AB56D62ADEF6EB004B5F3F /* FeedbackModeTip.swift */,
 			);
 			path = Toolbar;
 			sourceTree = "<group>";
@@ -1028,6 +1033,7 @@
 			isa = PBXGroup;
 			children = (
 				DAECE700296A1BC80025F875 /* CourseView.swift */,
+				65AB56D42ADEF60D004B5F3F /* CoursePickerTip.swift */,
 			);
 			path = Courses;
 			sourceTree = "<group>";
@@ -1346,6 +1352,7 @@
 				65B9BD102AAE413B0086F9EC /* FileUploadSubmissionServiceImpl.swift in Sources */,
 				E200F785297ECDB700DE269D /* FileView.swift in Sources */,
 				65E7972A2A1A4EF800E17401 /* ExamListItem.swift in Sources */,
+				65AB56D52ADEF60D004B5F3F /* CoursePickerTip.swift in Sources */,
 				658E4A322A61C7D600B43798 /* FloatingPointExtension.swift in Sources */,
 				650D88022A7A5C33004E7533 /* UMLUseCaseDiagramElementRenderer.swift in Sources */,
 				DAFFA3FB297F066200EA72B8 /* ArtemisDateHelpers.swift in Sources */,
@@ -1466,6 +1473,7 @@
 				65D2E1FF2A8CA4A8003DB837 /* CodeEditorSkeleton.swift in Sources */,
 				DA249E9829302531008DE1D5 /* PreviewAuthenticationViewModel.swift in Sources */,
 				650D88002A7A5B78004E7533 /* UMLDiagramRenderer.swift in Sources */,
+				65AB56D72ADEF6EB004B5F3F /* FeedbackModeTip.swift in Sources */,
 				E21AF054292B9D4C0096ACFC /* CodeView.swift in Sources */,
 				E2E460DD29292ECF00ECC0A5 /* Stack.swift in Sources */,
 				A9752D7B2992AAEB004441D1 /* ExamSectionDetailView.swift in Sources */,

--- a/Themis/ThemisApp.swift
+++ b/Themis/ThemisApp.swift
@@ -15,7 +15,7 @@ struct ThemisApp: App {
         WindowGroup {
             ContentView()
                 .task {
-//                    Tips.showAllTipsForTesting() // uncomment when debugging tips
+//                    try? Tips.resetDatastore() // uncomment when debugging tips
                     
                     try? Tips.configure([
                         .displayFrequency(.immediate),

--- a/Themis/ThemisApp.swift
+++ b/Themis/ThemisApp.swift
@@ -6,13 +6,22 @@
 //
 
 import SwiftUI
+import TipKit
 
 @main
 struct ThemisApp: App {
-
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .task {
+//                    Tips.showAllTipsForTesting() // uncomment when debugging tips
+                    
+                    try? Tips.configure([
+                        .displayFrequency(.immediate),
+                        .datastoreLocation(.applicationDefault)
+                    ])
+                }
         }
     }
 }

--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -82,6 +82,7 @@ struct AssessmentView: View {
                     if exercise.supportsReferencedFeedbacks {
                         ToolbarItem(placement: .navigationBarTrailing) {
                             ToolbarToggleButton(toggleVariable: $assessmentVM.pencilModeDisabled, iconImageSystemName: "hand.draw", inverted: true)
+                                .popoverTip(FeedbackModeTip())
                                 .disabled(!assessmentVM.allowsInlineFeedbackOperations)
                         }
                     }

--- a/Themis/Views/Assessment/Toolbar/FeedbackModeTip.swift
+++ b/Themis/Views/Assessment/Toolbar/FeedbackModeTip.swift
@@ -1,0 +1,26 @@
+//
+//  FeedbackModeTip.swift
+//  Themis
+//
+//  Created by Tarlan Ismayilsoy on 17.10.23.
+//
+
+import TipKit
+
+struct FeedbackModeTip: Tip {
+    var title: Text {
+        Text("Toggle Referenced Feedback Mode")
+    }
+    
+    var message: Text? {
+        Text("You can refer to individual parts of the submission to provide more detailed feedback")
+    }
+    
+    var image: Image? {
+        Image(systemName: "hand.tap")
+    }
+    
+    var options: [TipOption] {
+        Tips.MaxDisplayCount(1)
+    }
+}

--- a/Themis/Views/Courses/CoursePickerTip.swift
+++ b/Themis/Views/Courses/CoursePickerTip.swift
@@ -1,0 +1,26 @@
+//
+//  CoursePickerTip.swift
+//  Themis
+//
+//  Created by Tarlan Ismayilsoy on 17.10.23.
+//
+
+import TipKit
+
+struct CoursePickerTip: Tip {
+    var title: Text {
+        Text("Change the Course")
+    }
+    
+    var message: Text? {
+        Text("Choose the course where you want to perform assessments")
+    }
+    
+    var image: Image? {
+        Image(systemName: "rectangle.2.swap")
+    }
+    
+    var options: [TipOption] {
+        Tips.MaxDisplayCount(1)
+    }
+}

--- a/Themis/Views/Courses/CourseView.swift
+++ b/Themis/Views/Courses/CourseView.swift
@@ -107,18 +107,22 @@ struct CourseView: View {
             userFirstName
         }
         ToolbarItem(placement: .primaryAction) {
-            Picker("", selection: $courseVM.shownCourseID) {
-                ForEach(courseVM.pickerCourseIDs, id: \.self) { courseID in
-                    if let courseID {
-                        Text(courseVM.courseForID(id: courseID)?.title ?? "Invalid")
-                            .padding(.leading, 40)
+            Menu {
+                Picker("", selection: $courseVM.shownCourseID) {
+                    ForEach(courseVM.pickerCourseIDs, id: \.self) { courseID in
+                        if let courseID {
+                            Text(courseVM.courseForID(id: courseID)?.title ?? "Invalid")
+                                .padding(.leading, 40)
+                        }
                     }
                 }
+                .padding(-10) // compensates for Picker's default padding
+            } label: {
+                Text("Change Course")
             }
             .popoverTip(CoursePickerTip())
             .onChange(of: courseVM.shownCourseID) { courseVM.fetchShownCourseAndSetExercises() }
             .isHidden(courseVM.showCoursesIsEmptyMessage)
-            .padding(-10) // compensates for Picker's default padding
         }
     }
 }
@@ -127,6 +131,8 @@ struct CourseView_Previews: PreviewProvider {
     static var courseVM = CourseViewModel()
     
     static var previews: some View {
-        CourseView(courseVM: courseVM)
+        AuthenticatedPreview(authenticationVM: PreviewAuthenticationViewModel()) {
+            CourseView(courseVM: courseVM)
+        }
     }
 }

--- a/Themis/Views/Courses/CourseView.swift
+++ b/Themis/Views/Courses/CourseView.swift
@@ -115,7 +115,8 @@ struct CourseView: View {
                     }
                 }
             }
-            .onChange(of: courseVM.shownCourseID, perform: { _ in courseVM.fetchShownCourseAndSetExercises() })
+            .popoverTip(CoursePickerTip())
+            .onChange(of: courseVM.shownCourseID) { courseVM.fetchShownCourseAndSetExercises() }
             .isHidden(courseVM.showCoursesIsEmptyMessage)
             .padding(-10) // compensates for Picker's default padding
         }


### PR DESCRIPTION
This PR adds new popover tips created using the new TipKit available in iOS17. Also the design of the course picker is slightly changed to remove redundant course name information.

Closes #219 
Closes #201 

Course picker tip:
<img width="800" alt="course picker tip" src="https://github.com/ls1intum/Themis/assets/22798314/c698c108-c650-42ef-95ab-cfa2c5a05e65">

Feedback mode button tip:
<img width="800" alt="feedback tip" src="https://github.com/ls1intum/Themis/assets/22798314/21aab1df-639f-420c-87e4-e618c8bb5e79">


