### PR TITLE
`General`: Show an alert if the user is holding too many locks

### DIFF
--- a/Themis/ViewModels/Assessment/AssessmentViewModel.swift
+++ b/Themis/ViewModels/Assessment/AssessmentViewModel.swift
@@ -87,6 +87,11 @@ class AssessmentViewModel: ObservableObject {
             if case .decodingError(_, let statusCode) = (error as? APIClientError),
                statusCode == 200 { // Status is OK, but the body is not decodable (empty)
                 self.error = UserFacingError.noMoreAssessments
+            } else if let error = error as? APIClientError,
+                      case .jhipsterError = error {
+                var userFacingError = UserFacingError(error: error)
+                userFacingError.message = nil // message from the server is not user-friendly, so we remove it
+                self.error = userFacingError
             } else {
                 self.error = UserFacingError.unknown
             }


### PR DESCRIPTION
Closes #196 

When the user has locked too many submissions and attempts to start a new assessment, the following alert is shown:
<img width="250" alt="error alert" src="https://github.com/ls1intum/Themis/assets/22798314/3629a71b-11d1-4f34-b113-1f5aba291da9">