### PR TITLE
`Assessment View`: Enable feedback mode by default

### DIFF
--- a/Themis/Views/Assessment/AssessmentView.swift
+++ b/Themis/Views/Assessment/AssessmentView.swift
@@ -47,6 +47,7 @@ struct AssessmentView: View {
             .toolbarBackground(Color.themisPrimary, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .onAppear {
+                assessmentVM.pencilModeDisabled = assessmentVM.readOnly
                 assessmentResult.maxPoints = exercise.baseExercise.maxPoints ?? 100
             }
             .onDisappear {

--- a/Themis/Views/Assessment/Programming Exercise/ProgrammingAssessmentView.swift
+++ b/Themis/Views/Assessment/Programming Exercise/ProgrammingAssessmentView.swift
@@ -73,6 +73,7 @@ struct ProgrammingAssessmentView: View {
             }
         }
         .task {
+            assessmentVM.pencilModeDisabled = true
             await assessmentVM.initSubmission()
             
             if let pId = assessmentVM.participation?.id {


### PR DESCRIPTION
Closes #203 

This PR enables the feedback mode by default. It is only disabled if the exercise type is programming or if the assessment view is in read-only mode.