### PR TITLE
Add swiftlint 0.53.0 to fix build in CI

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1273,6 +1273,7 @@
 				657534A82A0F7A52004B0C3F /* XCRemoteSwiftPackageReference "artemis-ios-core-modules" */,
 				65F007962A86C837000FD641 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */,
 				06A99D3D2A94D99000E48066 /* XCRemoteSwiftPackageReference "Starscream" */,
+				0697E6F02B0653DD00534F5B /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = 83396D2B29155935003EF727 /* Products */;
 			projectDirPath = "";
@@ -1843,6 +1844,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0697E6F02B0653DD00534F5B /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = exactVersion;
+				version = 0.53.0;
+			};
+		};
 		06A99D3D2A94D99000E48066 /* XCRemoteSwiftPackageReference "Starscream" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/daltoniam/Starscream";


### PR DESCRIPTION
Currently, the build pipeline fails with the following output:
```
16-Nov-2023 13:41:41 | [13:41:41]: $ set -o pipefail && xcodebuild -scheme Themis -project ./Themis.xcodeproj -configuration Release -derivedDataPath .DerivedData -clonedSourcePackagesDirPath .SwiftPackages -destination 'generic/platform=iOS' -archivePath /Users/bamboobuildagent/Library/Developer/Xcode/Archives/2023-11-16/App\ 2023-11-16\ 13.41.41.xcarchive -skipPackagePluginValidation clean archive \| tee /Users/bamboobuildagent/Library/Logs/gym/Themis-Themis.log \| xcpretty
-- | --
16-Nov-2023 13:41:41 | [13:41:41]: ▸ Ignoring digest-crc-0.6.4 because its extensions are not built. Try: gem pristine digest-crc --version 0.6.4
16-Nov-2023 13:41:41 | [13:41:41]: ▸ Ignoring unf_ext-0.0.8.2 because its extensions are not built. Try: gem pristine unf_ext --version 0.0.8.2
16-Nov-2023 13:41:45 | [13:41:45]: ▸ Clean Succeeded
16-Nov-2023 13:41:49 | [13:41:49]: ▸ ** ARCHIVE FAILED **
16-Nov-2023 13:41:49 | [13:41:49]: ▸ The following build commands failed:
16-Nov-2023 13:41:49 | [13:41:49]: ▸         ComputeTargetDependencyGraph
16-Nov-2023 13:41:49 | [13:41:49]: ▸ (1 failure)
16-Nov-2023 13:41:49 | Ignoring digest-crc-0.6.4 because its extensions are not built. Try: gem pristine digest-crc --version 0.6.4
16-Nov-2023 13:41:49 | Ignoring unf_ext-0.0.8.2 because its extensions are not built. Try: gem pristine unf_ext --version 0.0.8.2
16-Nov-2023 13:41:49 | ▸ Clean Succeeded
16-Nov-2023 13:41:49 | ** ARCHIVE FAILED **
16-Nov-2023 13:41:49 |  
16-Nov-2023 13:41:49 |  
16-Nov-2023 13:41:49 | The following build commands failed:
16-Nov-2023 13:41:49 | ComputeTargetDependencyGraph
16-Nov-2023 13:41:49 | (1 failure)
16-Nov-2023 13:41:49 | [13:41:49]: Exit status: 65
16-Nov-2023 13:41:49 | [13:41:49]:
```

Setting the SwiftLint version to 0.53.0 (see https://github.com/realm/SwiftLint/issues/5352) fixes the issue and the builds succeed again.
