### PR TITLE
`Fix`: Cannot decode courses/for-dashboard endpoint return value 

### DIFF
--- a/Themis.xcodeproj/project.pbxproj
+++ b/Themis.xcodeproj/project.pbxproj
@@ -1877,7 +1877,7 @@
 			repositoryURL = "https://github.com/ls1intum/artemis-ios-core-modules";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 8.0.0;
 			};
 		};
 		65F007962A86C837000FD641 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {

--- a/Themis/ViewModels/Course/CourseViewModel.swift
+++ b/Themis/ViewModels/Course/CourseViewModel.swift
@@ -69,7 +69,7 @@ class CourseViewModel: ObservableObject {
                 log.error(String(describing: error))
             }
             
-            courses = coursesForDashboard.value?.map({ $0.course }).filter({ $0.isAtLeastTutorInCourse }) ?? []
+            courses = coursesForDashboard.value?.courses?.map({ $0.course }).filter({ $0.isAtLeastTutorInCourse }) ?? []
             showCoursesIsEmptyMessage = courses.isEmpty
             
             if !pickerCourseIDs.contains(where: { $0 == shownCourseID }) {


### PR DESCRIPTION
The return value of `courses/for-dashboard` was changed in Artemis and ArtemisCore was adapted to reflect this change. However, Themis was broken since it was using an old version of ArtemisCore. This PR updates the ArtemisCore dependency version to 8.0.0.